### PR TITLE
[Tooling] Deploy to Staging workflow and shared concurrency group

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -36,9 +36,9 @@ on:
 permissions:
   contents: read
 
-# Ensure only one PR tests against staging at a time
+# Ensure only one workflow interacts with staging at a time
 concurrency:
-  group: staging-cypress-tests
+  group: kinsta-staging
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,6 +30,12 @@ on:
       - master
       - main
       - development
+    paths-ignore:
+      - '.github/**'
+      - '.docs/**'
+      - '*.md'
+      - '.editorconfig'
+      - '.gitignore'
   # Allow manual triggering
   workflow_dispatch:
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Validate ref input
         run: |
-          if ! echo "$DEPLOY_REF" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+          if ! echo "$DEPLOY_REF" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._/-]*$'; then
             echo "Error: invalid ref '${DEPLOY_REF}'"
             exit 1
           fi
@@ -94,7 +94,13 @@ jobs:
             -H "Content-Type: application/json")
 
           http_code=$(echo "$response" | tail -n1)
-          echo "Cache clear response: $http_code"
+          body=$(echo "$response" | sed '$d')
+
+          echo "Cache clear HTTP status: $http_code"
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Cache clear response body:"
+            echo "$body"
+          fi
         env:
           KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
           KINSTA_SITE_ID: ${{ secrets.KINSTA_SITE_ID }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,6 +30,15 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Validate ref input
+        run: |
+          if ! echo "$DEPLOY_REF" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+            echo "Error: invalid ref '${DEPLOY_REF}'"
+            exit 1
+          fi
+        env:
+          DEPLOY_REF: ${{ github.event.inputs.ref }}
+
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
@@ -51,8 +60,7 @@ jobs:
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \
-             git checkout ${DEPLOY_REF} && \
-             git pull origin ${DEPLOY_REF} || true"
+             git checkout ${DEPLOY_REF}"
 
           echo "Deploy complete"
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,8 @@
-# Deploy Branch to Staging
+# Deploy Ref to Staging
 #
-# Manually deploy a branch or PR to Kinsta staging for review.
+# Manually deploy a branch or commit SHA to Kinsta staging for review.
 # Unlike the Cypress workflow, this does NOT reset staging afterwards —
-# the deployed branch persists until another deploy replaces it.
+# the deployed revision persists until another deploy replaces it.
 #
 # Uses the same secrets as the Cypress workflow — no additional setup needed.
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,111 @@
+# Deploy Branch to Staging
+#
+# Manually deploy a branch or PR to Kinsta staging for review.
+# Unlike the Cypress workflow, this does NOT reset staging afterwards —
+# the deployed branch persists until another deploy replaces it.
+#
+# Uses the same secrets as the Cypress workflow — no additional setup needed.
+
+name: Deploy to Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch name or commit SHA to deploy'
+        required: true
+        default: 'development'
+
+permissions:
+  contents: read
+
+# Ensure only one workflow interacts with staging at a time
+concurrency:
+  group: kinsta-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "$KINSTA_SSH_KEY" > ~/.ssh/kinsta_key
+          chmod 600 ~/.ssh/kinsta_key
+          ssh-keyscan -p "$KINSTA_SSH_PORT" "$KINSTA_SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+        env:
+          KINSTA_SSH_KEY: ${{ secrets.KINSTA_SSH_KEY }}
+          KINSTA_SSH_PORT: ${{ secrets.KINSTA_SSH_PORT }}
+          KINSTA_SSH_HOST: ${{ secrets.KINSTA_SFTP_HOST }}
+
+      - name: Deploy to staging
+        run: |
+          echo "Deploying ref to staging..."
+
+          ssh -i ~/.ssh/kinsta_key -p "$KINSTA_SSH_PORT" \
+            "${KINSTA_SSH_USER}@${KINSTA_SSH_HOST}" \
+            "cd public/wp-content/themes/novaramedia-com && \
+             git fetch origin && \
+             git reset --hard HEAD && \
+             git clean -fd && \
+             git checkout ${DEPLOY_REF} && \
+             git pull origin ${DEPLOY_REF} || true"
+
+          echo "Deploy complete"
+        env:
+          DEPLOY_REF: ${{ github.event.inputs.ref }}
+          KINSTA_SSH_PORT: ${{ secrets.KINSTA_SSH_PORT }}
+          KINSTA_SSH_USER: ${{ secrets.KINSTA_SSH_USER }}
+          KINSTA_SSH_HOST: ${{ secrets.KINSTA_SFTP_HOST }}
+
+      - name: Activate theme
+        run: |
+          ssh -i ~/.ssh/kinsta_key -p "$KINSTA_SSH_PORT" \
+            "${KINSTA_SSH_USER}@${KINSTA_SSH_HOST}" \
+            "cd public && wp theme activate novaramedia-com"
+        env:
+          KINSTA_SSH_PORT: ${{ secrets.KINSTA_SSH_PORT }}
+          KINSTA_SSH_USER: ${{ secrets.KINSTA_SSH_USER }}
+          KINSTA_SSH_HOST: ${{ secrets.KINSTA_SFTP_HOST }}
+
+      - name: Clear Kinsta cache
+        continue-on-error: true
+        run: |
+          if [ -z "$KINSTA_API_KEY" ] || [ -z "$KINSTA_SITE_ID" ] || [ -z "$KINSTA_STAGING_ENV_ID" ]; then
+            echo "Skipping cache clear - Kinsta API secrets not configured"
+            exit 0
+          fi
+
+          echo "Clearing Kinsta cache..."
+          response=$(curl -s -w "\n%{http_code}" -X POST \
+            "https://api.kinsta.com/v2/sites/${KINSTA_SITE_ID}/environments/${KINSTA_STAGING_ENV_ID}/clear-cache" \
+            -H "Authorization: Bearer ${KINSTA_API_KEY}" \
+            -H "Content-Type: application/json")
+
+          http_code=$(echo "$response" | tail -n1)
+          echo "Cache clear response: $http_code"
+        env:
+          KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
+          KINSTA_SITE_ID: ${{ secrets.KINSTA_SITE_ID }}
+          KINSTA_STAGING_ENV_ID: ${{ secrets.KINSTA_STAGING_ENV_ID }}
+
+      - name: Verify staging is accessible
+        run: |
+          echo "Checking staging site..."
+          sleep 5
+          http_code=$(curl -L -s -o /dev/null -w "%{http_code}" "$STAGING_URL")
+
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 400 ]; then
+            echo "Staging is live (HTTP $http_code)"
+          else
+            echo "Warning: staging returned HTTP $http_code"
+          fi
+        env:
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+
+      - name: Cleanup SSH keys
+        if: always()
+        run: rm -f ~/.ssh/kinsta_key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Deploy to Staging GitHub Actions workflow for manually deploying any branch to Kinsta staging persistently
+- `paths-ignore` filter on Cypress workflow to skip test runs for non-frontend changes (docs, workflows, config files)
+
 ### Changed
 
 - Optimise inline newsletter WP block data flow


### PR DESCRIPTION
Add a manual GitHub Actions workflow for persistently deploying any branch to Kinsta staging. Unlike the Cypress workflow, this does not reset staging afterwards — the deployed branch stays until replaced.

Update both workflows to share the `kinsta-staging` concurrency group so they cannot interact with staging simultaneously.