### PR TITLE
[Fix] Featured posts duplication when theme option slots are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix duplicate featured posts appearing above the fold when theme option slots are empty — `intval()` normalisation converted unset values to `0` before the fallback loop could fill them
+
 ### Changed
 
 - Optimise inline newsletter WP block data flow

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -247,12 +247,13 @@ function get_above_the_fold_featured_post_ids() {
     $featured_posts_ids[ $i - 1 ] = NM_get_option( 'nm_above_the_fold_featured_' . $i, 'nm_front_page_above_the_fold_featured_options' );
   }
 
-  // Normalize featured post IDs to integers for strict comparison
-  $featured_posts_ids = array_map( 'intval', $featured_posts_ids );
+  // Normalize latest featured post IDs to integers for strict comparison
   $latest_featured_posts_ids = array_map( 'intval', $latest_featured_posts_ids );
 
   for ( $i = 0; $i < 8; $i++ ) {
-    if ( ! is_numeric( $featured_posts_ids[ $i ] ) ) { // if the featured post id is not set in the theme options, use the latest featured post
+    $featured_posts_ids[ $i ] = intval( $featured_posts_ids[ $i ] );
+
+    if ( empty( $featured_posts_ids[ $i ] ) ) { // if the featured post id is not set in the theme options, use the latest featured post
       if ( ! empty( $latest_featured_posts_ids ) ) {
         while ( ! empty( $latest_featured_posts_ids ) && in_array( $latest_featured_posts_ids[0], $featured_posts_ids, true ) ) { // ensure fallback latest is not already in the theme options featured posts
           array_shift( $latest_featured_posts_ids );

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -247,11 +247,11 @@ function get_above_the_fold_featured_post_ids() {
     $featured_posts_ids[ $i - 1 ] = NM_get_option( 'nm_above_the_fold_featured_' . $i, 'nm_front_page_above_the_fold_featured_options' );
   }
 
-  // Normalize latest featured post IDs to integers for strict comparison
+  // Normalize all IDs to integers for strict comparison
   $latest_featured_posts_ids = array_map( 'intval', $latest_featured_posts_ids );
+  $featured_posts_ids = array_map( function( $id ) { return empty( $id ) ? 0 : intval( $id ); }, $featured_posts_ids );
 
   for ( $i = 0; $i < 8; $i++ ) {
-    $featured_posts_ids[ $i ] = intval( $featured_posts_ids[ $i ] );
 
     if ( empty( $featured_posts_ids[ $i ] ) ) { // if the featured post id is not set in the theme options, use the latest featured post
       if ( ! empty( $latest_featured_posts_ids ) ) {


### PR DESCRIPTION
The intval() normalisation added in a previous fix converted unset theme option values to 0 before the fallback loop ran. Since 0 is numeric, the `! is_numeric()` check never triggered, leaving empty slots as 0. WP then resolved post ID 0 to the current/first post, causing the same post to appear multiple times.

Fix: normalise each ID inline within the loop and use `empty()` instead of `! is_numeric()` to detect unset slots, since empty(0) is true.