### PR TITLE
Filter front page latest articles to News only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Front page latest articles column (above the fold) now shows only News posts
+
 ### Fixed
 
 - Survey 2026 banner link pointing to wrong domain

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -196,7 +196,7 @@ function check_for_apology_notice() {
  */
 function get_latest_articles_ids( $featured_posts_ids = false ) {
   $query_args = array(
-      'category_name'  => 'articles',
+      'category_name'  => 'news',
       'posts_per_page' => 7,
       'fields'         => 'ids',
       'post_status'    => 'publish',


### PR DESCRIPTION
## Summary

- Changes the above-the-fold "latest articles" column on the front page to only show posts from the **News** subcategory instead of all articles subcategories
- Updates changelog

## Test plan

- [ ] Verify front page right column above the fold only shows News posts
- [ ] Verify non-News articles (features, opinions, analysis) no longer appear in that column
- [ ] Confirm image slot fallback logic still works correctly with all-news posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)