### PR TITLE
Release 4.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.5.3] - 2026-04-08
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Survey 2026 banner link pointing to wrong domain
+
 ## [4.5.2] - 2026-03-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Front page latest articles column (above the fold) now shows only News posts
+
 ### Fixed
 
 - Survey 2026 banner link pointing to wrong domain

--- a/front-page.php
+++ b/front-page.php
@@ -21,17 +21,17 @@ $banners = array(
     // **************
 
     $featured_posts_ids = get_above_the_fold_featured_post_ids();
-    $latest_articles_posts_ids = get_latest_articles_ids($featured_posts_ids);
+    $latest_news_posts_ids = get_latest_news_ids($featured_posts_ids);
 
     get_template_part('partials/front-page/above-the-fold', null, array(
       'featured_posts_ids' => $featured_posts_ids,
-      'latest_articles_posts_ids' => $latest_articles_posts_ids,
+      'latest_news_posts_ids' => $latest_news_posts_ids,
     ));
 
     render_front_page_banner($banners[0]);
 
     get_template_part('partials/front-page/highlight-block', null, array(
-      'excluded_posts_ids' => array_merge($featured_posts_ids, $latest_articles_posts_ids),
+      'excluded_posts_ids' => array_merge($featured_posts_ids, $latest_news_posts_ids),
     ));
 
     get_template_part('partials/front-page/show-blocks/novara-live');

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -184,11 +184,11 @@ function check_for_apology_notice() {
   }
 }
 /**
- * Get the latest articles ids
- * This function will get the latest articles ids, excluding the featured posts if set
- * If the featured posts are not set, it will return the latest articles ids
- * If the latest articles are already in the featured posts, it will skip them
- * If there are no latest articles, it will return false
+ * Get the latest News article IDs
+ * Queries only the 'news' category, excluding the featured posts if set.
+ * If the featured posts are not set, it will return the latest news article IDs.
+ * If the latest articles are already in the featured posts, it will skip them.
+ * If there are no matching articles, it will return false.
  *
  * @param array $featured_posts_ids Array of featured post ids.
  *

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -192,7 +192,7 @@ function check_for_apology_notice() {
  *
  * @param array $featured_posts_ids Array of featured post ids.
  *
- * @return array/Boolean Array of latest articles ids or false if no latest articles
+ * @return array|false Array of latest News article IDs or false if none found
  */
 function get_latest_articles_ids( $featured_posts_ids = false ) {
   $query_args = array(

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -196,7 +196,7 @@ function check_for_apology_notice() {
  */
 function get_latest_articles_ids( $featured_posts_ids = false ) {
   $query_args = array(
-      'category_name'  => 'articles',
+      'category_name'  => 'news',
       'posts_per_page' => 7,
       'fields'         => 'ids',
       'post_status'    => 'publish',

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -184,17 +184,16 @@ function check_for_apology_notice() {
   }
 }
 /**
- * Get the latest News article IDs
+ * Get the latest News article IDs.
  * Queries only the 'news' category, excluding the featured posts if set.
- * If the featured posts are not set, it will return the latest news article IDs.
- * If the latest articles are already in the featured posts, it will skip them.
- * If there are no matching articles, it will return false.
+ * Always returns an array — empty if there are no matching posts — so callers
+ * can safely pass the result to array_merge() and similar array functions.
  *
- * @param array $featured_posts_ids Array of featured post ids.
+ * @param array $featured_posts_ids Array of featured post ids to exclude.
  *
- * @return array|false Array of latest News article IDs or false if none found
+ * @return int[] Array of latest News post IDs (empty if none found).
  */
-function get_latest_articles_ids( $featured_posts_ids = false ) {
+function get_latest_news_ids( $featured_posts_ids = false ) {
   $query_args = array(
       'category_name'  => 'news',
       'posts_per_page' => 7,
@@ -213,12 +212,10 @@ function get_latest_articles_ids( $featured_posts_ids = false ) {
   $recent_articles = new WP_Query( $query_args );
 
   if ( ! $recent_articles->have_posts() ) {
-    return false;
+    return array();
   }
 
-  $latest_articles_ids = $recent_articles->posts;
-
-  return $latest_articles_ids;
+  return $recent_articles->posts;
 }
 /**
  * Get the featured post ids for the above the fold section

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "novaramedia-com",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "novaramedia-com",
-      "version": "4.5.2",
+      "version": "4.5.3",
       "license": "ISC",
       "dependencies": {
         "jquery": "~3.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novaramedia-com",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "No Future, Utopia Now",
   "main": "gulpfile.js",
   "scripts": {

--- a/partials/front-page/above-the-fold.php
+++ b/partials/front-page/above-the-fold.php
@@ -11,8 +11,8 @@ if ( $args['featured_posts_ids'] ) {
     return;
 }
 
-if ( $args['latest_articles_posts_ids'] ) {
-    $latest_articles_posts_ids = $args['latest_articles_posts_ids'];
+if ( $args['latest_news_posts_ids'] ) {
+    $latest_news_posts_ids = $args['latest_news_posts_ids'];
 } else {
     return;
 }
@@ -37,7 +37,7 @@ if ( $args['latest_articles_posts_ids'] ) {
             'partials/front-page/above-the-fold/latest-articles',
             null,
             array(
-                'latest_articles_posts_ids' => $latest_articles_posts_ids,
+                'latest_news_posts_ids' => $latest_news_posts_ids,
             )
         );
         ?>

--- a/partials/front-page/above-the-fold/latest-articles.php
+++ b/partials/front-page/above-the-fold/latest-articles.php
@@ -1,12 +1,12 @@
 <?php
-  if ( empty( $args['latest_articles_posts_ids'] ) ) {
+  if ( empty( $args['latest_news_posts_ids'] ) ) {
     return;
   }
-  $latest_articles_posts_ids = $args['latest_articles_posts_ids'];
+  $latest_news_posts_ids = $args['latest_news_posts_ids'];
 
   $recent_articles = new WP_Query(
     array(
-      'post__in' => $latest_articles_posts_ids,
+      'post__in' => $latest_news_posts_ids,
       'orderby' => 'post__in',
     )
   );

--- a/partials/specials/banners/survey-link.php
+++ b/partials/specials/banners/survey-link.php
@@ -6,7 +6,7 @@
  * preset text with a CTA button on the other.
  */
 
-$url = 'https://novaramedia.com/survey2026';
+$url = 'https://novara.media/survey2026';
 ?>
 <div class="survey-link-banner container">
   <div class="grid-row">

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Novara Media v4
 Theme URI: novaramedia.com
 Description: No Future, Utopia Now
-Version: 4.5.2
+Version: 4.5.3
 Author: Novara Media
 Author URI: novaramedia.com
 */


### PR DESCRIPTION
## Release 4.5.3

## [4.5.3] - 2026-04-08

### Changed

- Front page latest articles column (above the fold) now shows only News posts

### Fixed

- Survey 2026 banner link pointing to wrong domain

---
Generated by `scripts/release.sh`