### PR TITLE
Fix YouTube embeds failing in Safari (native iframe lazy-load)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `nm_known_video_page()` helper drives conditional `preconnect`/`dns-prefetch` for the YouTube embed origin
-- YouTube embed iframe accepts optional `$loading` ('lazy' default, 'eager' for above-the-fold) and `$title` (context for accessible title attribute) arguments
-
-### Changed
-
-- YouTube embeds use native `loading="lazy"` instead of lazysizes `data-src` swap
-
 ### Fixed
 
 - Header menu spacing on mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `nm_known_video_page()` helper drives conditional `preconnect`/`dns-prefetch` for the YouTube embed origin
+- YouTube embed iframe accepts optional `$loading` ('lazy' default, 'eager' for above-the-fold) and `$title` (context for accessible title attribute) arguments
+
 ### Changed
 
 - YouTube embeds use native `loading="lazy"` instead of lazysizes `data-src` swap
@@ -15,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Header menu spacing on mobile
 - YouTube embeds failing to load in Safari
+- YouTube embed iframes missing accessible `title` attribute
 
 ## [4.5.3] - 2026-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- YouTube embeds use native `loading="lazy"` instead of lazysizes `data-src` swap
+
 ### Fixed
 
 - Header menu spacing on mobile
+- YouTube embeds failing to load in Safari
 
 ## [4.5.3] - 2026-04-08
 

--- a/category-do-your-own-research.php
+++ b/category-do-your-own-research.php
@@ -117,7 +117,7 @@ get_header();
             <div class="dyor-archive__latest-episode-image grid-item is-xxl-16 is-s-24 mb-s-4">
               <div class="u-video-embed-container ui-rounded-image">
                 <?php if ( ! empty( $latest_meta['_cmb_utube'][0] ) ) { ?>
-                  <?php echo render_youtube_embed_iframe( $latest_meta['_cmb_utube'][0] ); ?>
+                  <?php echo render_youtube_embed_iframe( $latest_meta['_cmb_utube'][0], false, 'lazy', get_the_title() ); ?>
                 <?php } else { ?>
                   <?php render_thumbnail( get_the_ID(), 'col16-16to9', array( 'class' => 'ui-rounded-image' ) ); ?>
                 <?php } ?>

--- a/category-do-your-own-research.php
+++ b/category-do-your-own-research.php
@@ -117,7 +117,7 @@ get_header();
             <div class="dyor-archive__latest-episode-image grid-item is-xxl-16 is-s-24 mb-s-4">
               <div class="u-video-embed-container ui-rounded-image">
                 <?php if ( ! empty( $latest_meta['_cmb_utube'][0] ) ) { ?>
-                  <?php echo render_youtube_embed_iframe( $latest_meta['_cmb_utube'][0], true, false ); ?>
+                  <?php echo render_youtube_embed_iframe( $latest_meta['_cmb_utube'][0] ); ?>
                 <?php } else { ?>
                   <?php render_thumbnail( get_the_ID(), 'col16-16to9', array( 'class' => 'ui-rounded-image' ) ); ?>
                 <?php } ?>

--- a/category-do-your-own-research.php
+++ b/category-do-your-own-research.php
@@ -117,7 +117,7 @@ get_header();
             <div class="dyor-archive__latest-episode-image grid-item is-xxl-16 is-s-24 mb-s-4">
               <div class="u-video-embed-container ui-rounded-image">
                 <?php if ( ! empty( $latest_meta['_cmb_utube'][0] ) ) { ?>
-                  <?php echo render_youtube_embed_iframe( $latest_meta['_cmb_utube'][0], false, 'lazy', get_the_title() ); ?>
+                  <?php echo render_youtube_embed_iframe( $latest_meta['_cmb_utube'][0], false, 'eager', get_the_title() ); ?>
                 <?php } else { ?>
                   <?php render_thumbnail( get_the_ID(), 'col16-16to9', array( 'class' => 'ui-rounded-image' ) ); ?>
                 <?php } ?>

--- a/category-downstream.php
+++ b/category-downstream.php
@@ -91,7 +91,7 @@ if ( have_posts() ) {
       <div class="grid-item is-s-24 is-l-14 is-xxl-16 mb-s-4">
         <?php if ( $featured_youtube_id ) { ?>
           <div class="u-video-embed-container ui-rounded-image">
-            <?php echo render_youtube_embed_iframe( $featured_youtube_id ); ?>
+            <?php echo render_youtube_embed_iframe( $featured_youtube_id, false, 'lazy', get_the_title( $featured_post_id ) ); ?>
           </div>
         <?php } else { ?>
           <div class="layout-thumbnail-frame">

--- a/category-downstream.php
+++ b/category-downstream.php
@@ -91,7 +91,7 @@ if ( have_posts() ) {
       <div class="grid-item is-s-24 is-l-14 is-xxl-16 mb-s-4">
         <?php if ( $featured_youtube_id ) { ?>
           <div class="u-video-embed-container ui-rounded-image">
-            <?php echo render_youtube_embed_iframe( $featured_youtube_id, false, false ); ?>
+            <?php echo render_youtube_embed_iframe( $featured_youtube_id ); ?>
           </div>
         <?php } else { ?>
           <div class="layout-thumbnail-frame">

--- a/category-downstream.php
+++ b/category-downstream.php
@@ -91,7 +91,7 @@ if ( have_posts() ) {
       <div class="grid-item is-s-24 is-l-14 is-xxl-16 mb-s-4">
         <?php if ( $featured_youtube_id ) { ?>
           <div class="u-video-embed-container ui-rounded-image">
-            <?php echo render_youtube_embed_iframe( $featured_youtube_id, false, 'lazy', get_the_title( $featured_post_id ) ); ?>
+            <?php echo render_youtube_embed_iframe( $featured_youtube_id, false, 'eager', get_the_title( $featured_post_id ) ); ?>
           </div>
         <?php } else { ?>
           <div class="layout-thumbnail-frame">

--- a/category-novara-live.php
+++ b/category-novara-live.php
@@ -35,7 +35,7 @@ get_header();
     <div class="novara-live-archive__liveplayer grid-row">
       <div class="grid-item is-xxl-24">
         <div class="u-video-embed-container">
-          <?php echo render_youtube_embed_iframe( $embed_id, true, true ); ?>
+          <?php echo render_youtube_embed_iframe( $embed_id, true ); ?>
         </div>
       </div>
     </div>

--- a/category-novara-live.php
+++ b/category-novara-live.php
@@ -35,7 +35,7 @@ get_header();
     <div class="novara-live-archive__liveplayer grid-row">
       <div class="grid-item is-xxl-24">
         <div class="u-video-embed-container">
-          <?php echo render_youtube_embed_iframe( $embed_id, true ); ?>
+          <?php echo render_youtube_embed_iframe( $embed_id, true, 'eager' ); ?>
         </div>
       </div>
     </div>

--- a/category-novara-live.php
+++ b/category-novara-live.php
@@ -35,7 +35,7 @@ get_header();
     <div class="novara-live-archive__liveplayer grid-row">
       <div class="grid-item is-xxl-24">
         <div class="u-video-embed-container">
-          <?php echo render_youtube_embed_iframe( $embed_id, true, 'eager' ); ?>
+          <?php echo render_youtube_embed_iframe( $embed_id, true, 'eager', 'Novara Live' ); ?>
         </div>
       </div>
     </div>

--- a/category.php
+++ b/category.php
@@ -94,7 +94,7 @@ if ($category->slug === 'video') {
           if (!empty($meta['_cmb_utube'])) {
           ?>
           <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0] ); ?>
+            <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], false, 'lazy', get_the_title() ); ?>
           </div>
           <a href="<?php the_permalink(); ?>">
             <h6 class="text-wrap-pretty mt-2 font-size-13 font-weight-bold"><?php the_title(); ?></h6>

--- a/category.php
+++ b/category.php
@@ -94,7 +94,7 @@ if ($category->slug === 'video') {
           if (!empty($meta['_cmb_utube'])) {
           ?>
           <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], true ); ?>
+            <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0] ); ?>
           </div>
           <a href="<?php the_permalink(); ?>">
             <h6 class="text-wrap-pretty mt-2 font-size-13 font-weight-bold"><?php the_title(); ?></h6>

--- a/header.php
+++ b/header.php
@@ -10,7 +10,11 @@
   <link rel="preconnect" href="https://donate.novaramedia.com" crossorigin />
   <link rel="preconnect" href="https://use.typekit.net" crossorigin />
   <link rel="preconnect" href="https://p.typekit.net" crossorigin />
-  <link rel="preconnect" href="https://www.youtube-nocookie.com" crossorigin />
+  <?php if ( nm_known_video_page() ) { ?>
+  <link rel="preconnect" href="https://www.youtube-nocookie.com" />
+  <?php } else { ?>
+  <link rel="dns-prefetch" href="https://www.youtube-nocookie.com" />
+  <?php } ?>
   <link rel="preload" as="style" href="https://use.typekit.net/aki7elm.css" />
   <?php
     get_template_part( 'partials/header/seo' );

--- a/header.php
+++ b/header.php
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://donate.novaramedia.com" crossorigin />
   <link rel="preconnect" href="https://use.typekit.net" crossorigin />
   <link rel="preconnect" href="https://p.typekit.net" crossorigin />
+  <link rel="preconnect" href="https://www.youtube-nocookie.com" crossorigin />
   <link rel="preload" as="style" href="https://use.typekit.net/aki7elm.css" />
   <?php
     get_template_part( 'partials/header/seo' );

--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://use.typekit.net" crossorigin />
   <link rel="preconnect" href="https://p.typekit.net" crossorigin />
   <?php if ( nm_known_video_page() ) { ?>
-  <link rel="preconnect" href="https://www.youtube-nocookie.com" />
+  <link rel="preconnect" href="https://www.youtube-nocookie.com" crossorigin />
   <?php } else { ?>
   <link rel="dns-prefetch" href="https://www.youtube-nocookie.com" />
   <?php } ?>

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -651,17 +651,26 @@ function generate_youtube_embed_url( $id, $autoplay = false ) {
 function nm_known_video_page() {
   if ( is_singular() ) {
     $queried = get_queried_object();
-    if ( $queried && ! empty( get_post_meta( $queried->ID, '_cmb_utube', true ) ) ) {
-      return true;
+    if ( $queried ) {
+      if ( ! empty( get_post_meta( $queried->ID, '_cmb_utube', true ) ) ) {
+        return true;
+      }
+      if ( ! empty( get_post_meta( $queried->ID, '_nm_support_youtube', true ) ) ) {
+        return true;
+      }
+      // page-how-we-are-funded.php hardcodes a fallback video ID when meta is empty.
+      if ( is_page( 'how-we-are-funded' ) ) {
+        return true;
+      }
     }
   }
 
-  if ( is_category( array( 'downstream', 'do-your-own-research', 'novara-live' ) ) ) {
-    return true;
-  }
-
-  if ( is_page( array( 'how-we-are-funded', 'support' ) ) ) {
-    return true;
+  if ( is_category() ) {
+    $term       = get_queried_object();
+    $video_term = get_term_by( 'slug', 'video', 'category' );
+    if ( $term && $video_term && ( $term->term_id === $video_term->term_id || cat_is_ancestor_of( $video_term, $term ) ) ) {
+      return true;
+    }
   }
 
   if ( is_front_page() ) {

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -624,7 +624,7 @@ function only_child_category_filter( $category ) {
  * Create youtube embed url with consistent parameters
  *
  * @param string $id Youtube video ID.
- * @param boolean $autoplay Set true if the video autoplay function is required (only posible on internal website linking due to browser policy).
+ * @param boolean $autoplay Set true if the video autoplay function is required (only possible on internal website linking due to browser policy).
  *
  * @return string Valid youtube iframe src url
  */

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -623,8 +623,6 @@ function only_child_category_filter( $category ) {
 /**
  * Create youtube embed url with consistent parameters
  *
- * Note the option to use the lazysizes for lazyloading the iframe https://github.com/aFarkas/lazysizes
- *
  * @param string $id Youtube video ID.
  * @param boolean $autoplay Set true if the video autoplay function is required (only posible on internal website linking due to browser policy).
  *
@@ -638,6 +636,39 @@ function generate_youtube_embed_url( $id, $autoplay = false ) {
   }
 
   return $url;
+}
+
+/**
+ * Fuzzy whitelist of contexts where a YouTube embed is likely present.
+ *
+ * Used by header.php to decide between `preconnect` (when we're confident a
+ * YouTube iframe will load) and `dns-prefetch` (everywhere else). False
+ * negatives fall through to dns-prefetch, which is safe — the iframe still
+ * loads, just without an open TLS connection waiting for it.
+ *
+ * @return boolean True if the current request is likely to render a YouTube embed.
+ */
+function nm_known_video_page() {
+  if ( is_singular() ) {
+    $queried = get_queried_object();
+    if ( $queried && ! empty( get_post_meta( $queried->ID, '_cmb_utube', true ) ) ) {
+      return true;
+    }
+  }
+
+  if ( is_category( array( 'downstream', 'do-your-own-research', 'novara-live' ) ) ) {
+    return true;
+  }
+
+  if ( is_page( array( 'how-we-are-funded', 'support' ) ) ) {
+    return true;
+  }
+
+  if ( is_front_page() ) {
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/lib/renderers.php
+++ b/lib/renderers.php
@@ -1,29 +1,19 @@
 <?php
 /**
  * Generate complete YouTube embed iframe HTML.
- * Handles both lazy loading and regular loading scenarios.
+ * Uses native iframe lazy loading via the `loading="lazy"` attribute.
  *
  * @param string $youtube_id YouTube video ID.
- * @param boolean $lazyload Set true to use lazy loading via lazysizes library (uses data-src instead of src).
  * @param boolean $autoplay Set true if the video autoplay function is required (only possible on internal website linking due to browser policy).
  *
  * @return string Complete iframe HTML element for YouTube embed
  */
-function render_youtube_embed_iframe( $youtube_id, $lazyload = false, $autoplay = false ) {
+function render_youtube_embed_iframe( $youtube_id, $autoplay = false ) {
   $url = generate_youtube_embed_url( $youtube_id, $autoplay );
   $allow_attr = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
 
-  $classes = 'youtube-player';
-  if ( $lazyload ) {
-    $classes .= ' lazyload';
-  }
-
-  $src_attr = $lazyload ? 'data-src' : 'src';
-
   $iframe = sprintf(
-    '<iframe class="%s" type="text/html" %s="%s" allow="%s" allowfullscreen></iframe>',
-    esc_attr( $classes ),
-    $src_attr,
+    '<iframe class="youtube-player" type="text/html" src="%s" allow="%s" loading="lazy" allowfullscreen></iframe>',
     esc_url( $url ),
     esc_attr( $allow_attr )
   );

--- a/lib/renderers.php
+++ b/lib/renderers.php
@@ -1,21 +1,27 @@
 <?php
 /**
  * Generate complete YouTube embed iframe HTML.
- * Uses native iframe lazy loading via the `loading="lazy"` attribute.
+ * Defaults to native iframe lazy loading; pass 'eager' for above-the-fold embeds.
  *
- * @param string $youtube_id YouTube video ID.
- * @param boolean $autoplay Set true if the video autoplay function is required (only possible on internal website linking due to browser policy).
+ * @param string  $youtube_id YouTube video ID.
+ * @param boolean $autoplay   Set true to enable autoplay (only effective when browser policy allows, typically after internal navigation).
+ * @param string  $loading    Iframe loading strategy: 'lazy' (default) or 'eager'.
+ * @param string  $title      Optional context for the iframe title attribute (e.g. the post title). A "YouTube video player" prefix is applied automatically.
  *
- * @return string Complete iframe HTML element for YouTube embed
+ * @return string Complete iframe HTML element for YouTube embed.
  */
-function render_youtube_embed_iframe( $youtube_id, $autoplay = false ) {
-  $url = generate_youtube_embed_url( $youtube_id, $autoplay );
+function render_youtube_embed_iframe( $youtube_id, $autoplay = false, $loading = 'lazy', $title = '' ) {
+  $url        = generate_youtube_embed_url( $youtube_id, $autoplay );
   $allow_attr = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
+  $loading    = $loading === 'eager' ? 'eager' : 'lazy';
+  $title_attr = $title !== '' ? 'YouTube video player: ' . $title : 'YouTube video player';
 
   $iframe = sprintf(
-    '<iframe class="youtube-player" type="text/html" src="%s" allow="%s" loading="lazy" allowfullscreen></iframe>',
+    '<iframe class="youtube-player" type="text/html" src="%s" title="%s" allow="%s" loading="%s" allowfullscreen></iframe>',
     esc_url( $url ),
-    esc_attr( $allow_attr )
+    esc_attr( $title_attr ),
+    esc_attr( $allow_attr ),
+    esc_attr( $loading )
   );
 
   return $iframe;

--- a/page-how-we-are-funded.php
+++ b/page-how-we-are-funded.php
@@ -44,7 +44,7 @@ if ( have_posts() ) {
               <div class="grid-item is-xxl-12 is-m-24">
                 <div class="p-4 p-s-3 font-weight-bold">
                   <div class="u-video-embed-container only-mobile mt-2 mb-4">
-                    <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
+                    <?php echo render_youtube_embed_iframe( $youtube_id, false, 'eager', get_the_title() ); ?>
                   </div>
                   <div class="font-size-15 font-size-l-14 font-size-s-14 mb-4">
                     <span class="font-color-red">We believe in the power of people</span> to build a new media for a different politics.
@@ -69,7 +69,7 @@ if ( have_posts() ) {
                 if ( $youtube_id ) {
                   ?>
                   <div class="u-video-embed-container">
-                    <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
+                    <?php echo render_youtube_embed_iframe( $youtube_id, false, 'eager', get_the_title() ); ?>
                   </div>
                   <?php
                 }

--- a/page-how-we-are-funded.php
+++ b/page-how-we-are-funded.php
@@ -44,7 +44,7 @@ if ( have_posts() ) {
               <div class="grid-item is-xxl-12 is-m-24">
                 <div class="p-4 p-s-3 font-weight-bold">
                   <div class="u-video-embed-container only-mobile mt-2 mb-4">
-                    <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
+                    <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
                   </div>
                   <div class="font-size-15 font-size-l-14 font-size-s-14 mb-4">
                     <span class="font-color-red">We believe in the power of people</span> to build a new media for a different politics.
@@ -69,7 +69,7 @@ if ( have_posts() ) {
                 if ( $youtube_id ) {
                   ?>
                   <div class="u-video-embed-container">
-                    <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
+                    <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
                   </div>
                   <?php
                 }

--- a/page-how-we-are-funded.php
+++ b/page-how-we-are-funded.php
@@ -44,7 +44,7 @@ if ( have_posts() ) {
               <div class="grid-item is-xxl-12 is-m-24">
                 <div class="p-4 p-s-3 font-weight-bold">
                   <div class="u-video-embed-container only-mobile mt-2 mb-4">
-                    <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
+                    <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
                   </div>
                   <div class="font-size-15 font-size-l-14 font-size-s-14 mb-4">
                     <span class="font-color-red">We believe in the power of people</span> to build a new media for a different politics.
@@ -69,7 +69,7 @@ if ( have_posts() ) {
                 if ( $youtube_id ) {
                   ?>
                   <div class="u-video-embed-container">
-                    <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
+                    <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
                   </div>
                   <?php
                 }

--- a/page-support.php
+++ b/page-support.php
@@ -95,7 +95,7 @@ if ( have_posts() ) {
                 if ( $youtube_id ) {
                   ?>
                 <div class="u-video-embed-container">
-                  <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
+                  <?php echo render_youtube_embed_iframe( $youtube_id, false, 'eager', get_the_title() ); ?>
                 </div>
                   <?php
                 }
@@ -128,7 +128,7 @@ if ( have_posts() ) {
         <div class="grid-item is-xxl-24 only-desktop">
           <div class="background-white ui-rounded-box ui-rounded-box--bottom pl-5 pl-l-4 pr-5 pr-l-4 pb-5 pb-l-4">
             <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, false, 'eager', get_the_title() ); ?>
             </div>
           </div>
         </div>

--- a/page-support.php
+++ b/page-support.php
@@ -95,7 +95,7 @@ if ( have_posts() ) {
                 if ( $youtube_id ) {
                   ?>
                 <div class="u-video-embed-container">
-                  <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
+                  <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
                 </div>
                   <?php
                 }
@@ -128,7 +128,7 @@ if ( have_posts() ) {
         <div class="grid-item is-xxl-24 only-desktop">
           <div class="background-white ui-rounded-box ui-rounded-box--bottom pl-5 pl-l-4 pr-5 pr-l-4 pb-5 pb-l-4">
             <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
             </div>
           </div>
         </div>

--- a/page__newsletter.php
+++ b/page__newsletter.php
@@ -45,7 +45,7 @@ if( have_posts() ) {
             if ($youtube_id) {
           ?>
           <div class="u-video-embed-container mb-4">
-            <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, true, 'lazy', get_the_title() ); ?>
           </div>
           <?php
             } else {

--- a/page__newsletter.php
+++ b/page__newsletter.php
@@ -45,7 +45,7 @@ if( have_posts() ) {
             if ($youtube_id) {
           ?>
           <div class="u-video-embed-container mb-4">
-            <?php echo render_youtube_embed_iframe( $youtube_id, true, 'lazy', get_the_title() ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, true, 'eager', get_the_title() ); ?>
           </div>
           <?php
             } else {

--- a/page__newsletter.php
+++ b/page__newsletter.php
@@ -45,7 +45,7 @@ if( have_posts() ) {
             if ($youtube_id) {
           ?>
           <div class="u-video-embed-container mb-4">
-            <?php echo render_youtube_embed_iframe( $youtube_id, false, true ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
           </div>
           <?php
             } else {

--- a/partials/front-page/above-the-fold/featured-post-primary.php
+++ b/partials/front-page/above-the-fold/featured-post-primary.php
@@ -53,7 +53,7 @@ if ( $show_related && ! empty( $meta['_cmb_related_posts'] ) ) {
 if ( $has_embed ) {
   ?>
 <div class="u-video-embed-container background-black">
-  <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], true ); ?>
+  <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0] ); ?>
 </div>
   <?php
 } else {

--- a/partials/front-page/above-the-fold/featured-post-primary.php
+++ b/partials/front-page/above-the-fold/featured-post-primary.php
@@ -53,7 +53,7 @@ if ( $show_related && ! empty( $meta['_cmb_related_posts'] ) ) {
 if ( $has_embed ) {
   ?>
 <div class="u-video-embed-container background-black">
-  <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0] ); ?>
+  <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], false, 'eager', get_the_title() ); ?>
 </div>
   <?php
 } else {

--- a/partials/home-fundraiser.php
+++ b/partials/home-fundraiser.php
@@ -1,5 +1,12 @@
 <?php
-// @deprecated Not referenced anywhere in the theme. Uses legacy col grid. Safe to delete.
+/**
+ * Home fundraiser partial.
+ *
+ * @deprecated Not referenced anywhere in the theme. Uses legacy col grid.
+ *             Safe to delete. Left in place pending cleanup — the single
+ *             `render_youtube_embed_iframe()` call here is intentionally
+ *             not updated to the new signature since this file is unused.
+ */
 $fundraiser_youtube_id = IGV_get_option( '_igv_fundraiser_youtube_id' );
 if ( $fundraiser_youtube_id ) {
   ?>

--- a/partials/post-layouts/archive-post.php
+++ b/partials/post-layouts/archive-post.php
@@ -18,7 +18,7 @@ $youtube_id = $show_video_embed ? get_post_meta( $this_post_id, '_cmb_utube', tr
 <article <?php post_class( $args['grid-item-classes'] ); ?> id="post-<?php the_ID(); ?>">
   <?php if ( $youtube_id ) { ?>
     <div class="u-video-embed-container ui-rounded-image">
-      <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
+      <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
     </div>
   <?php } elseif ( $is_show_tags ) { ?>
     <div class="layout-thumbnail-frame">

--- a/partials/post-layouts/archive-post.php
+++ b/partials/post-layouts/archive-post.php
@@ -18,7 +18,7 @@ $youtube_id = $show_video_embed ? get_post_meta( $this_post_id, '_cmb_utube', tr
 <article <?php post_class( $args['grid-item-classes'] ); ?> id="post-<?php the_ID(); ?>">
   <?php if ( $youtube_id ) { ?>
     <div class="u-video-embed-container ui-rounded-image">
-      <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
+      <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title( $this_post_id ) ); ?>
     </div>
   <?php } elseif ( $is_show_tags ) { ?>
     <div class="layout-thumbnail-frame">

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -53,7 +53,7 @@
         }
     ?>
       <div class="u-video-embed-container">
-        <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], true, $autoplay ); ?>
+        <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], $autoplay ); ?>
       </div>
     <?php
       } else {

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -53,7 +53,7 @@
         }
     ?>
       <div class="u-video-embed-container">
-        <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], $autoplay ); ?>
+        <?php echo render_youtube_embed_iframe( $meta['_cmb_utube'][0], $autoplay, 'eager', get_the_title() ); ?>
       </div>
     <?php
       } else {

--- a/partials/specials/banners/support-video.php
+++ b/partials/specials/banners/support-video.php
@@ -27,7 +27,7 @@ if ( $support_page !== null ) {
         } else {
           $video_id = 'c6hfjBmzt5c';
         }
-        echo render_youtube_embed_iframe( $video_id, false, 'lazy', 'Support video' );
+        echo render_youtube_embed_iframe( $video_id, false, 'eager', 'Support video' );
         ?>
       </div>
     </div>

--- a/partials/specials/banners/support-video.php
+++ b/partials/specials/banners/support-video.php
@@ -27,7 +27,7 @@ if ( $support_page !== null ) {
         } else {
           $video_id = 'c6hfjBmzt5c';
         }
-        echo render_youtube_embed_iframe( $video_id, true );
+        echo render_youtube_embed_iframe( $video_id );
         ?>
       </div>
     </div>

--- a/partials/specials/banners/support-video.php
+++ b/partials/specials/banners/support-video.php
@@ -27,7 +27,7 @@ if ( $support_page !== null ) {
         } else {
           $video_id = 'c6hfjBmzt5c';
         }
-        echo render_youtube_embed_iframe( $video_id );
+        echo render_youtube_embed_iframe( $video_id, false, 'lazy', 'Support video' );
         ?>
       </div>
     </div>

--- a/single-event.php
+++ b/single-event.php
@@ -57,7 +57,7 @@ if ( have_posts() ) {
           ?>
         <div class="grid-item offset-s-0 is-s-24 offset-xxl-4 is-xxl-16">
           <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, false, 'eager', get_the_title() ); ?>
           </div>
         </div>
           <?php

--- a/single-event.php
+++ b/single-event.php
@@ -57,7 +57,7 @@ if ( have_posts() ) {
           ?>
         <div class="grid-item offset-s-0 is-s-24 offset-xxl-4 is-xxl-16">
           <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, false, 'lazy', get_the_title() ); ?>
           </div>
         </div>
           <?php

--- a/single-event.php
+++ b/single-event.php
@@ -57,7 +57,7 @@ if ( have_posts() ) {
           ?>
         <div class="grid-item offset-s-0 is-s-24 offset-xxl-4 is-xxl-16">
           <div class="u-video-embed-container">
-            <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id ); ?>
           </div>
         </div>
           <?php

--- a/single-newsletter.php
+++ b/single-newsletter.php
@@ -48,7 +48,7 @@ if ( have_posts() ) {
           if ( $youtube_id ) {
             ?>
           <div class="u-video-embed-container mb-4">
-            <?php echo render_youtube_embed_iframe( $youtube_id, true, true ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
           </div>
             <?php
           } else {

--- a/single-newsletter.php
+++ b/single-newsletter.php
@@ -48,7 +48,7 @@ if ( have_posts() ) {
           if ( $youtube_id ) {
             ?>
           <div class="u-video-embed-container mb-4">
-            <?php echo render_youtube_embed_iframe( $youtube_id, true, 'lazy', get_the_title() ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, true, 'eager', get_the_title() ); ?>
           </div>
             <?php
           } else {

--- a/single-newsletter.php
+++ b/single-newsletter.php
@@ -48,7 +48,7 @@ if ( have_posts() ) {
           if ( $youtube_id ) {
             ?>
           <div class="u-video-embed-container mb-4">
-            <?php echo render_youtube_embed_iframe( $youtube_id, true ); ?>
+            <?php echo render_youtube_embed_iframe( $youtube_id, true, 'lazy', get_the_title() ); ?>
           </div>
             <?php
           } else {


### PR DESCRIPTION
## Summary

- Replaces the lazysizes `data-src` → `src` swap on YouTube iframes with the browser-native `loading=\"lazy\"` attribute.
- Fixes Safari desktop + iOS failing YouTube embeds with \"Error 153 Video player configuration error\" on pages like `/category/video/do-your-own-research/`. The JS src-swap raced the YouTube player config handshake under Safari's ITP; a real `src` at parse time avoids the race.
- Simplifies `render_youtube_embed_iframe()` — drops the `\$lazyload` parameter so every call site is lazy by default. 13 call sites updated.
- Adds a `preconnect` to `youtube-nocookie.com` in `header.php` to recover some of the early-connection behaviour we lose by dropping lazysizes on iframes.

Browser support for iframe `loading=\"lazy\"`: Chrome/Edge 77+, Opera 64+, Samsung 12+, Safari 16.4+, Firefox 121+ (~96% global). Unsupported browsers ignore the attribute and load the iframe eagerly — no breakage.

`lazysizes` is still bundled and used for `<img>` via the existing filter and for SoundCloud players.

## Test plan

- [x] Safari desktop: `/category/video/do-your-own-research/` — latest episode iframe loads and plays.
- [ ] Safari iOS: same page loads without error.
- [ ] Regression: `/category/video/downstream/`, front page featured video, single video post, `/support/`, `/about/how-we-are-funded/`, Novara Live, newsletter with video.
- [ ] Chrome/Firefox: confirm iframes still lazy-load (DevTools → Network → iframe request deferred until near viewport).
- [x] Confirm no console errors about missing `.lazyload` CSS rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)