### PR TITLE
Make Cypress tests resilient to stale Kinsta cache

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"65a31bba-2c44-4cd4-b585-d1e305fd70ce","pid":61446,"acquiredAt":1776785967872}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"65a31bba-2c44-4cd4-b585-d1e305fd70ce","pid":61446,"acquiredAt":1776785967872}

--- a/.docs/ci-speedup-plan.md
+++ b/.docs/ci-speedup-plan.md
@@ -160,8 +160,9 @@ Go to https://github.com/novaramedia/novaramedia-com/settings/secrets/actions
 | Secret                  | Value                                               |
 | ----------------------- | --------------------------------------------------- |
 | `KINSTA_API_KEY`        | Kinsta API key (from MyKinsta > Company > API Keys) |
-| `KINSTA_SITE_ID`        | Site ID (visible in MyKinsta URL or via API)        |
 | `KINSTA_STAGING_ENV_ID` | Staging environment ID (via Kinsta API)             |
+
+The cache-clear step calls `POST /v2/sites/tools/clear-cache` with the environment ID in the request body, so `KINSTA_SITE_ID` is no longer required.
 
 **Can be removed** (no longer needed):
 
@@ -244,7 +245,6 @@ Prefix every env-specific secret with the environment:
 Shared (not env-specific):
 
 - `KINSTA_API_KEY`
-- `KINSTA_SITE_ID`
 
 ### Migration steps
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,6 @@
 # - KINSTA_SSH_PORT: SSH port (Kinsta uses non-standard ports)
 # - STAGING_URL: Full URL of staging site (e.g., https://staging-novaramedia.kinsta.cloud)
 # - KINSTA_API_KEY: Kinsta API key for cache clearing (optional but recommended)
-# - KINSTA_SITE_ID: Kinsta site ID (optional, for cache clearing)
 # - KINSTA_STAGING_ENV_ID: Kinsta staging environment ID (optional, for cache clearing)
 #
 # One-time server setup required — see .docs/ci-speedup-plan.md
@@ -106,11 +105,6 @@ jobs:
       # Cache clear is best-effort - cypress/support/e2e.js appends a
       # ?cypress_cache_bust=... query string to every cy.visit() so tests
       # always fetch fresh HTML even if this step fails. Warnings here are
-      # surfaced via ::warning:: annotations so stale IDs are visible in the
-      # GitHub UI without blocking the workflow.
-      # Cache clear is best-effort - cypress/support/e2e.js appends a
-      # ?cypress_cache_bust=... query string to every cy.visit() so tests
-      # always fetch fresh HTML even if this step fails. Warnings here are
       # surfaced via ::warning:: annotations so issues are visible in the
       # GitHub UI without blocking the workflow.
       #
@@ -124,11 +118,14 @@ jobs:
           fi
 
           echo "Clearing Kinsta cache..."
-          response=$(curl -s -w "\n%{http_code}" -X POST \
+          if ! response=$(curl -s -w "\n%{http_code}" -X POST \
             "https://api.kinsta.com/v2/sites/tools/clear-cache" \
             -H "Authorization: Bearer ${KINSTA_API_KEY}" \
             -H "Content-Type: application/json" \
-            -d "{\"environment_id\": \"${KINSTA_STAGING_ENV_ID}\"}")
+            -d "{\"environment_id\": \"${KINSTA_STAGING_ENV_ID}\"}"); then
+            echo "::warning::Kinsta cache clear curl failed (network/DNS error) - continuing, cypress cache-bust will handle freshness"
+            exit 0
+          fi
 
           http_code=$(echo "$response" | tail -n1)
           body=$(echo "$response" | sed '$d')
@@ -144,7 +141,6 @@ jobs:
           sleep 10
         env:
           KINSTA_API_KEY: ${{ secrets.KINSTA_API_KEY }}
-          KINSTA_SITE_ID: ${{ secrets.KINSTA_SITE_ID }}
           KINSTA_STAGING_ENV_ID: ${{ secrets.KINSTA_STAGING_ENV_ID }}
 
       - name: Verify staging is accessible

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -155,6 +155,17 @@ jobs:
 
             if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 400 ]; then
               echo "Staging site is accessible (HTTP $http_code)"
+
+              # Diagnostic: list data-testid values present on the homepage.
+              # Helps debug cases where a test asserts a testid but the
+              # template branch that emits it is skipped (e.g. above-the-fold
+              # returns early when no featured posts are configured).
+              echo "--- data-testid values on staging homepage ---"
+              curl -L -s "${STAGING_URL}/?cypress_cache_bust=$(date +%s)" \
+                | grep -oE 'data-testid="[^"]+"' \
+                | sort -u \
+                || echo "(no data-testid attributes found)"
+              echo "--- end testid diagnostic ---"
               exit 0
             fi
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -108,30 +108,33 @@ jobs:
       # always fetch fresh HTML even if this step fails. Warnings here are
       # surfaced via ::warning:: annotations so stale IDs are visible in the
       # GitHub UI without blocking the workflow.
+      # Cache clear is best-effort - cypress/support/e2e.js appends a
+      # ?cypress_cache_bust=... query string to every cy.visit() so tests
+      # always fetch fresh HTML even if this step fails. Warnings here are
+      # surfaced via ::warning:: annotations so issues are visible in the
+      # GitHub UI without blocking the workflow.
+      #
+      # Endpoint reference: https://api-docs.kinsta.com/api-reference/wordpress-site-tools/clear-site-cache
       - name: Clear Kinsta cache
         continue-on-error: true
         run: |
-          if [ -z "$KINSTA_API_KEY" ] || [ -z "$KINSTA_SITE_ID" ] || [ -z "$KINSTA_STAGING_ENV_ID" ]; then
+          if [ -z "$KINSTA_API_KEY" ] || [ -z "$KINSTA_STAGING_ENV_ID" ]; then
             echo "::warning::Kinsta API secrets not configured - skipping cache clear (cypress cache-bust will handle freshness)"
             exit 0
           fi
 
           echo "Clearing Kinsta cache..."
           response=$(curl -s -w "\n%{http_code}" -X POST \
-            "https://api.kinsta.com/v2/sites/${KINSTA_SITE_ID}/environments/${KINSTA_STAGING_ENV_ID}/clear-cache" \
+            "https://api.kinsta.com/v2/sites/tools/clear-cache" \
             -H "Authorization: Bearer ${KINSTA_API_KEY}" \
-            -H "Content-Type: application/json")
+            -H "Content-Type: application/json" \
+            -d "{\"environment_id\": \"${KINSTA_STAGING_ENV_ID}\"}")
 
           http_code=$(echo "$response" | tail -n1)
           body=$(echo "$response" | sed '$d')
 
           echo "Cache clear response: $http_code"
           echo "$body"
-
-          if [ "$http_code" = "404" ]; then
-            echo "::warning::Kinsta returned 404 - KINSTA_SITE_ID or KINSTA_STAGING_ENV_ID is stale. Refresh from https://api.kinsta.com/v2/sites"
-            exit 0
-          fi
 
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
             echo "::warning::Kinsta cache clear returned HTTP $http_code"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -160,12 +160,15 @@ jobs:
               # template branch that emits it is skipped (e.g. above-the-fold
               # returns early when no featured posts are configured).
               echo "--- data-testid values on staging homepage ---"
-              testid_html=$(curl -L -s "${STAGING_URL}/?cypress_cache_bust=$(date +%s)")
-              testid_matches=$(printf '%s' "$testid_html" | grep -oE 'data-testid="[^"]+"' | sort -u || true)
-              if [ -n "$testid_matches" ]; then
-                printf '%s\n' "$testid_matches"
+              if ! testid_html=$(curl -L -sS --connect-timeout 10 --max-time 30 "${STAGING_URL}/?cypress_cache_bust=$(date +%s)"); then
+                echo "::warning::testid diagnostic curl failed (network/timeout) - skipping"
               else
-                echo "(no data-testid attributes found)"
+                testid_matches=$(printf '%s' "$testid_html" | grep -oE 'data-testid="[^"]+"' | sort -u || true)
+                if [ -n "$testid_matches" ]; then
+                  printf '%s\n' "$testid_matches"
+                else
+                  echo "(no data-testid attributes found)"
+                fi
               fi
               echo "--- end testid diagnostic ---"
               exit 0

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -103,11 +103,16 @@ jobs:
           KINSTA_SSH_USER: ${{ secrets.KINSTA_SSH_USER }}
           KINSTA_SSH_HOST: ${{ secrets.KINSTA_SFTP_HOST }}
 
+      # Cache clear is best-effort - cypress/support/e2e.js appends a
+      # ?cypress_cache_bust=... query string to every cy.visit() so tests
+      # always fetch fresh HTML even if this step fails. Warnings here are
+      # surfaced via ::warning:: annotations so stale IDs are visible in the
+      # GitHub UI without blocking the workflow.
       - name: Clear Kinsta cache
         continue-on-error: true
         run: |
           if [ -z "$KINSTA_API_KEY" ] || [ -z "$KINSTA_SITE_ID" ] || [ -z "$KINSTA_STAGING_ENV_ID" ]; then
-            echo "Skipping cache clear - Kinsta API secrets not configured"
+            echo "::warning::Kinsta API secrets not configured - skipping cache clear (cypress cache-bust will handle freshness)"
             exit 0
           fi
 
@@ -122,6 +127,16 @@ jobs:
 
           echo "Cache clear response: $http_code"
           echo "$body"
+
+          if [ "$http_code" = "404" ]; then
+            echo "::warning::Kinsta returned 404 - KINSTA_SITE_ID or KINSTA_STAGING_ENV_ID is stale. Refresh from https://api.kinsta.com/v2/sites"
+            exit 0
+          fi
+
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::warning::Kinsta cache clear returned HTTP $http_code"
+            exit 0
+          fi
 
           sleep 10
         env:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -160,10 +160,13 @@ jobs:
               # template branch that emits it is skipped (e.g. above-the-fold
               # returns early when no featured posts are configured).
               echo "--- data-testid values on staging homepage ---"
-              curl -L -s "${STAGING_URL}/?cypress_cache_bust=$(date +%s)" \
-                | grep -oE 'data-testid="[^"]+"' \
-                | sort -u \
-                || echo "(no data-testid attributes found)"
+              testid_html=$(curl -L -s "${STAGING_URL}/?cypress_cache_bust=$(date +%s)")
+              testid_matches=$(printf '%s' "$testid_html" | grep -oE 'data-testid="[^"]+"' | sort -u || true)
+              if [ -n "$testid_matches" ]; then
+                printf '%s\n' "$testid_matches"
+              else
+                echo "(no data-testid attributes found)"
+              fi
               echo "--- end testid diagnostic ---"
               exit 0
             fi

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -118,12 +118,12 @@ jobs:
           fi
 
           echo "Clearing Kinsta cache..."
-          if ! response=$(curl -s -w "\n%{http_code}" -X POST \
+          if ! response=$(curl -sS --connect-timeout 10 --max-time 30 -w "\n%{http_code}" -X POST \
             "https://api.kinsta.com/v2/sites/tools/clear-cache" \
             -H "Authorization: Bearer ${KINSTA_API_KEY}" \
             -H "Content-Type: application/json" \
             -d "{\"environment_id\": \"${KINSTA_STAGING_ENV_ID}\"}"); then
-            echo "::warning::Kinsta cache clear curl failed (network/DNS error) - continuing, cypress cache-bust will handle freshness"
+            echo "::warning::Kinsta cache clear curl failed (network/DNS/timeout) - check KINSTA_API_KEY and endpoint reachability; cypress cache-bust will handle freshness"
             exit 0
           fi
 
@@ -134,7 +134,7 @@ jobs:
           echo "$body"
 
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
-            echo "::warning::Kinsta cache clear returned HTTP $http_code"
+            echo "::warning::Kinsta cache clear returned HTTP $http_code - check KINSTA_STAGING_ENV_ID and KINSTA_API_KEY secrets / endpoint path"
             exit 0
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ cypress.env.json
 test*.log
 
 # Build artifacts
-dist/report.html
+dist/report.html.claude/

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -11,7 +11,7 @@ describe('Homepage', () => {
   });
 
   it('should load successfully', () => {
-    cy.url().should('eq', Cypress.config('baseUrl') + '/');
+    cy.location('pathname').should('eq', '/');
     cy.title().should('not.be.empty');
     cy.title().should('include', 'Novara Media');
   });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -11,6 +11,19 @@ import './commands';
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
+// Bypass Kinsta full-page cache by appending a unique query string to every
+// cy.visit(). Kinsta skips the page cache when a query string is present, so
+// this guarantees the test fetches freshly-deployed HTML even if the API-based
+// cache clear fails or the IDs drift.
+Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
+  if (typeof url === 'string') {
+    const separator = url.includes('?') ? '&' : '?';
+    const cacheBuster = `cypress_cache_bust=${Date.now()}`;
+    return originalVisit(`${url}${separator}${cacheBuster}`, options);
+  }
+  return originalVisit(url, options);
+});
+
 // Set up console error spy before every test so verifyNoConsoleErrors() works.
 // Using cy.on() ensures the listener is scoped to the current test and cleaned
 // up automatically, preventing listener stacking across tests.

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -14,17 +14,25 @@ import './commands';
 // Bypass Kinsta full-page cache by appending a unique query string to every
 // cy.visit(). Kinsta skips the page cache when a query string is present, so
 // this guarantees the test fetches freshly-deployed HTML even if the API-based
-// cache clear fails or the IDs drift.
-Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
-  if (typeof url === 'string') {
-    const hashIndex = url.indexOf('#');
-    const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
-    const fragment = hashIndex === -1 ? '' : url.slice(hashIndex);
-    const separator = base.includes('?') ? '&' : '?';
-    const cacheBuster = `cypress_cache_bust=${Date.now()}`;
-    return originalVisit(`${base}${separator}${cacheBuster}${fragment}`, options);
+// cache clear fails or the IDs drift. Handles both cy.visit(url, options) and
+// cy.visit({ url, ... }) signatures.
+const appendCacheBust = (url) => {
+  const hashIndex = url.indexOf('#');
+  const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const fragment = hashIndex === -1 ? '' : url.slice(hashIndex);
+  const separator = base.includes('?') ? '&' : '?';
+  const cacheBuster = `cypress_cache_bust=${Date.now()}`;
+  return `${base}${separator}${cacheBuster}${fragment}`;
+};
+
+Cypress.Commands.overwrite('visit', (originalVisit, urlOrOptions, options) => {
+  if (typeof urlOrOptions === 'string') {
+    return originalVisit(appendCacheBust(urlOrOptions), options);
   }
-  return originalVisit(url, options);
+  if (urlOrOptions && typeof urlOrOptions === 'object' && typeof urlOrOptions.url === 'string') {
+    return originalVisit({ ...urlOrOptions, url: appendCacheBust(urlOrOptions.url) });
+  }
+  return originalVisit(urlOrOptions, options);
 });
 
 // Set up console error spy before every test so verifyNoConsoleErrors() works.

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -17,9 +17,12 @@ import './commands';
 // cache clear fails or the IDs drift.
 Cypress.Commands.overwrite('visit', (originalVisit, url, options) => {
   if (typeof url === 'string') {
-    const separator = url.includes('?') ? '&' : '?';
+    const hashIndex = url.indexOf('#');
+    const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
+    const fragment = hashIndex === -1 ? '' : url.slice(hashIndex);
+    const separator = base.includes('?') ? '&' : '?';
     const cacheBuster = `cypress_cache_bust=${Date.now()}`;
-    return originalVisit(`${url}${separator}${cacheBuster}`, options);
+    return originalVisit(`${base}${separator}${cacheBuster}${fragment}`, options);
   }
   return originalVisit(url, options);
 });


### PR DESCRIPTION
## Summary

- `cy.visit()` now appends `?cypress_cache_bust=<timestamp>` to every navigation so Kinsta's page cache is always bypassed — tests see freshly-deployed HTML even when the cache-clear API call fails or the IDs drift.
- Cache-clear step no longer silently succeeds: a 404 (or any non-2xx) now emits a `::warning::` annotation pointing at stale `KINSTA_SITE_ID` / `KINSTA_STAGING_ENV_ID`, while still letting the workflow proceed.

## Why

On run [24730970669](https://github.com/novaramedia/novaramedia-com/actions/runs/24730970669) the homepage test failed with `Expected to find element: [data-testid="post-list"]`. Root cause: the Kinsta cache-clear call returned **HTTP 404** (stale env IDs after a staging rebuild), so staging served cached HTML from before the `data-testid` attributes were added. `continue-on-error: true` hid the problem.

## Test plan

- [ ] CI run on this PR should see this workflow succeed end-to-end, with cache-clear surfacing a `::warning::` (until secrets refreshed)
- [ ] Homepage test `should display post content` should now pass because `cy.visit('/')` becomes `cy.visit('/?cypress_cache_bust=...')`, bypassing Kinsta page cache
- [ ] After merging, refresh `KINSTA_SITE_ID` + `KINSTA_STAGING_ENV_ID` secrets from Kinsta API so the warning clears on future runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)