### PR TITLE
feat: add NM_DATE_FORMAT_LONG constant for date display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `NM_DATE_FORMAT_LONG` constant for long-form date display (#499)
-
 ### Changed
 
-- Migrate `'j F Y'` literals across templates to `NM_DATE_FORMAT_LONG`
+- Replace hard-coded `'j F Y'` date literals with `NM_DATE_FORMAT_LONG` constant (#499)
 
 ## [4.5.5] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `NM_DATE_FORMAT_LONG` constant for long-form date display (#499)
+
+### Changed
+
+- Migrate `'j F Y'` literals across templates to `NM_DATE_FORMAT_LONG`
+
 ## [4.5.5] - 2026-04-27
 
 ### Added

--- a/category-novara-live.php
+++ b/category-novara-live.php
@@ -66,7 +66,7 @@ get_header();
         <div class="grid-item is-s-12 is-xxl-6 mb-4">
           <a href="<?php the_permalink(); ?>">
             <?php the_post_thumbnail('col6-16to9'); ?>
-            <h6 class="font-size-10 font-weight-semibold mt-1"><?php the_time('j F Y'); ?></h6>
+            <h6 class="font-size-10 font-weight-semibold mt-1"><?php the_time(NM_DATE_FORMAT_LONG); ?></h6>
             <h6 class="text-wrap-pretty font-size-11 font-size-s-10 font-weight-semibold mt-1"><?php the_title(); ?></h6>
           </a>
         </div>

--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Long-form date display format (e.g. "12 June 2010") used across event,
+ * post and archive templates. Single source of truth — see issue #499.
+ */
+define( 'NM_DATE_FORMAT_LONG', 'j F Y' );
+
+/**
  * Enqueues the compiled main.js and main.css files with localized WordPress data.
  *
  * Registers and enqueues the theme's main JavaScript file with a global WP object

--- a/functions.php
+++ b/functions.php
@@ -6,6 +6,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Long-form date display format (e.g. "12 June 2010") used across event,
  * post and archive templates. Single source of truth — see issue #499.
+ *
+ * Part of the Novara styleguide — https://github.com/novaramedia/styleguide-novara-io
  */
 define( 'NM_DATE_FORMAT_LONG', 'j F Y' );
 

--- a/partials/front-page/show-blocks/audio.php
+++ b/partials/front-page/show-blocks/audio.php
@@ -102,7 +102,7 @@ function render_show( $slug, $description, $logo_url = null, $background_color =
               <div class="grid-item is-m-24 is-xxl-12 mt-2 mb-2">
                 <a href="<?php echo esc_url( get_the_permalink( $post_id ) ); ?>" class="ui-hover">
                   <div class="font-size-8 font-weight-bold mb-2">
-                    <?php echo esc_html( get_the_time( 'j F Y', $post_id ) ); ?>
+                    <?php echo esc_html( get_the_time( NM_DATE_FORMAT_LONG, $post_id ) ); ?>
                   </div>
                 </a>
                 <h4 class="font-size-10 font-weight-bold mb-2">

--- a/partials/front-page/show-blocks/novara-live.php
+++ b/partials/front-page/show-blocks/novara-live.php
@@ -126,7 +126,7 @@ if ( $novara_live_category ) {
                   <div class="layout-split-level font-size-8 font-weight-bold mb-1">
                   <?php render_post_ui_tags( $post->ID, false, true, 'no-fill--white' ); ?>
                   <a href="<?php the_permalink(); ?>" class="ui-hover">
-                    <span><?php echo ( $i < 6 ) ? '<span class="js-time-since" data-timestamp="' . $timestamp . '"></span>' : get_the_time( 'j F Y' ); ?></span>
+                    <span><?php echo ( $i < 6 ) ? '<span class="js-time-since" data-timestamp="' . $timestamp . '"></span>' : get_the_time( NM_DATE_FORMAT_LONG ); ?></span>
                   </a>
                   </div>
                   <a href="<?php the_permalink(); ?>" class="ui-hover">

--- a/partials/post-layouts/archive-event.php
+++ b/partials/post-layouts/archive-event.php
@@ -36,7 +36,7 @@ if ( $timestamp ) {
   </div>
   <div class="grid-item is-xxl-14 is-s-24">
     <a href="<?php the_permalink(); ?>" class="ui-hover">
-      <h3 class="font-weight-bold mb-2"><?php echo $time->format( 'j F Y' ); ?>:</h3>
+      <h3 class="font-weight-bold mb-2"><?php echo $time->format( NM_DATE_FORMAT_LONG ); ?>:</h3>
       <h2 class="font-size-13 font-weight-bold text-wrap-balance mb-3"><?php the_title(); ?></h2>
     </a>
     <?php

--- a/partials/post-layouts/list-post.php
+++ b/partials/post-layouts/list-post.php
@@ -10,7 +10,7 @@
 ?>
 <div <?php post_class($args['grid-item-classes']); ?>>
   <a href="<?php the_permalink() ?>">
-    <span class="font-size-9"><?php the_time('j F Y'); ?></span>
+    <span class="font-size-9"><?php the_time(NM_DATE_FORMAT_LONG); ?></span>
     <h3 class="font-size-9 font-weight-semibold"><?php the_title(); ?></h3>
   </a>
 </div>

--- a/partials/singles/articles/articles-header-basic-no-image.php
+++ b/partials/singles/articles/articles-header-basic-no-image.php
@@ -11,6 +11,6 @@
       }
     ?>
     <h3 class="font-size-11 font-weight-bold">by <?php render_bylines($post->ID, true); ?></h3>
-    <h3 class="font-size-11 font-weight-bold"><?php the_time('j F Y'); ?></h3>
+    <h3 class="font-size-11 font-weight-bold"><?php the_time(NM_DATE_FORMAT_LONG); ?></h3>
   </div>
 </div>

--- a/partials/singles/articles/articles-header-basic.php
+++ b/partials/singles/articles/articles-header-basic.php
@@ -11,7 +11,7 @@
       }
     ?>
     <h3 class="font-size-11 font-weight-bold">by <?php render_bylines($post->ID, true); ?></h3>
-    <h3 class="font-size-11 font-weight-bold"><?php the_time('j F Y'); ?></h3>
+    <h3 class="font-size-11 font-weight-bold"><?php the_time(NM_DATE_FORMAT_LONG); ?></h3>
   </div>
   <div class="grid-item is-s-24 is-m-8 is-xxl-10">
     <?php render_thumbnail($post->ID, 'col20', array(

--- a/partials/singles/articles/articles-header-large-image.php
+++ b/partials/singles/articles/articles-header-large-image.php
@@ -17,7 +17,7 @@
       }
     ?>
     <h3 class="font-size-11 font-weight-bold">by <?php render_bylines($post->ID, true); ?></h3>
-    <h3 class="font-size-11 font-weight-bold"><?php the_time('j F Y'); ?></h3>
+    <h3 class="font-size-11 font-weight-bold"><?php the_time(NM_DATE_FORMAT_LONG); ?></h3>
   </div>
 </div>
 <div class="grid-row mb-4">

--- a/partials/singles/single-post-audio.php
+++ b/partials/singles/single-post-audio.php
@@ -34,7 +34,7 @@
 <div class="grid-row mb-4 font-size-9">
   <div class="grid-item is-s-24 is-m-10 is-xxl-12 mb-s-2">
     <ul class="inline-action-list">
-      <li>Published <?php the_time('j F Y'); ?></li>
+      <li>Published <?php the_time(NM_DATE_FORMAT_LONG); ?></li>
       <?php
         if (!empty($resources)) {
           echo '<li><a class="u-pointer" id="js-resources-toggle">Resources</a></li>';

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -19,7 +19,7 @@
 <div class="grid-row mb-4 font-size-9">
   <div class="grid-item is-s-24 is-m-10 is-xxl-12 mb-s-3">
     <ul class="inline-action-list">
-      <li>Published <?php the_time('j F Y'); ?></li>
+      <li>Published <?php the_time(NM_DATE_FORMAT_LONG); ?></li>
       <?php
         if (!empty($resources)) {
           echo '<li><a class="u-pointer" id="js-resources-toggle">Resources</a></li>';

--- a/single-event.php
+++ b/single-event.php
@@ -47,7 +47,7 @@ if ( have_posts() ) {
       </div>
       <div class="grid-row mb-4">
         <div class="grid-item is-xxl-24 text-align-center">
-          <h3 class="font-size-10 font-weight-bold mb-2"><?php echo $time->format( 'j F Y' ); ?></h3>
+          <h3 class="font-size-10 font-weight-bold mb-2"><?php echo $time->format( NM_DATE_FORMAT_LONG ); ?></h3>
           <h1 class="font-size-15 font-weight-bold text-wrap-balance"><?php the_title(); ?></h1>
         </div>
       </div>
@@ -74,7 +74,7 @@ if ( have_posts() ) {
         <div class="grid-item offset-s-0 is-s-24 offset-xxl-2 is-xxl-8">
           <div class="mb-4">
             <h5 class="font-size-10 font-weight-bold mb-2">Time:</h5>
-            <h3 class="font-size-12 font-weight-bold"><?php echo $time->format( 'j F Y' ); ?></h3>
+            <h3 class="font-size-12 font-weight-bold"><?php echo $time->format( NM_DATE_FORMAT_LONG ); ?></h3>
             <h3 class="font-size-12 font-weight-bold"><?php echo $time->format( 'H:i' ); ?></h3>
           </div>
         <?php

--- a/single-job.php
+++ b/single-job.php
@@ -36,7 +36,7 @@ if ( have_posts() ) {
         }
           the_content();
         ?>
-        <p>Closing date: <?php echo gmdate( 'j F Y', $meta['_nm_deadline'][0] ); ?></p>
+        <p>Closing date: <?php echo gmdate( NM_DATE_FORMAT_LONG, $meta['_nm_deadline'][0] ); ?></p>
       </div>
     </div>
   </article>

--- a/single-notice.php
+++ b/single-notice.php
@@ -17,7 +17,7 @@ if( have_posts() ) {
       <article class="grid-item is-s-24 is-xl-14 is-xxl-10">
         <header class="mb-4">
           <h5 class="font-weight-bold"><?php the_title(); ?></h5>
-          <h5><?php the_time('j F Y'); ?></h5>
+          <h5><?php the_time(NM_DATE_FORMAT_LONG); ?></h5>
         </header>
         <div class="page-copy">
           <?php the_content(); ?>


### PR DESCRIPTION
## Summary
- Adds `NM_DATE_FORMAT_LONG` (`'j F Y'`) constant in `functions.php` as single source of truth for long-form date display
- Migrates all 13 template call sites that hard-coded the `'j F Y'` literal
- Future blocks (e.g. `nm-wp/related-post` on `feature/related-post-block`) should reference the constant instead of duplicating the string

## Affected files
- `functions.php` (constant defined)
- `single-event.php`, `single-job.php`, `single-notice.php`, `category-novara-live.php`
- `partials/post-layouts/{archive-event,list-post}.php`
- `partials/singles/articles/articles-header-{basic,basic-no-image,large-image}.php`
- `partials/singles/single-post-{audio,video}.php`
- `partials/front-page/show-blocks/{audio,novara-live}.php`

## Test plan
- [ ] No visual regression on event archive, single event, single job/notice, articles archives, audio/video singles
- [ ] Front-page audio + novara-live blocks render dates correctly
- [ ] `php -l` clean across all touched files
- [ ] `npm run build` clean (no template-side build impact, but verify)

Closes #499