### PR TITLE
Fix: staging deploy not pulling latest commits

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,7 +61,11 @@ jobs:
              git reset --hard HEAD && \
              git clean -fd && \
              git checkout ${DEPLOY_REF} && \
-             (git reset --hard origin/${DEPLOY_REF} 2>/dev/null || git reset --hard ${DEPLOY_REF})"
+             if git show-ref --verify --quiet refs/remotes/origin/${DEPLOY_REF}; then \
+               git reset --hard origin/${DEPLOY_REF}; \
+             else \
+               git reset --hard ${DEPLOY_REF}; \
+             fi"
 
           echo "Deploy complete"
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,7 +60,7 @@ jobs:
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \
-             git switch -- \"${DEPLOY_REF}\" && \
+             git checkout \"${DEPLOY_REF}\" && \
              if git show-ref --verify --quiet refs/remotes/origin/${DEPLOY_REF}; then \
                git reset --hard \"origin/${DEPLOY_REF}\"; \
              else \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Validate ref input
         run: |
-          if ! echo "$DEPLOY_REF" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._/-]*$'; then
+          if ! printf '%s' "$DEPLOY_REF" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._/-]*$'; then
             echo "Error: invalid ref '${DEPLOY_REF}'"
             exit 1
           fi
@@ -60,11 +60,11 @@ jobs:
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \
-             git checkout ${DEPLOY_REF} && \
+             git checkout -- \"${DEPLOY_REF}\" && \
              if git show-ref --verify --quiet refs/remotes/origin/${DEPLOY_REF}; then \
-               git reset --hard origin/${DEPLOY_REF}; \
+               git reset --hard -- \"origin/${DEPLOY_REF}\"; \
              else \
-               git reset --hard ${DEPLOY_REF}; \
+               git reset --hard -- \"${DEPLOY_REF}\"; \
              fi"
 
           echo "Deploy complete"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,11 +60,11 @@ jobs:
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \
-             git checkout -- \"${DEPLOY_REF}\" && \
+             git switch -- \"${DEPLOY_REF}\" && \
              if git show-ref --verify --quiet refs/remotes/origin/${DEPLOY_REF}; then \
-               git reset --hard -- \"origin/${DEPLOY_REF}\"; \
+               git reset --hard \"origin/${DEPLOY_REF}\"; \
              else \
-               git reset --hard -- \"${DEPLOY_REF}\"; \
+               git reset --hard \"${DEPLOY_REF}\"; \
              fi"
 
           echo "Deploy complete"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,7 +60,8 @@ jobs:
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \
-             git checkout ${DEPLOY_REF}"
+             git checkout ${DEPLOY_REF} && \
+             (git reset --hard origin/${DEPLOY_REF} 2>/dev/null || git reset --hard ${DEPLOY_REF})"
 
           echo "Deploy complete"
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Validate ref input
         run: |
-          if ! printf '%s' "$DEPLOY_REF" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._/-]*$'; then
+          if [[ ! "$DEPLOY_REF" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
             echo "Error: invalid ref '${DEPLOY_REF}'"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- `git checkout <branch>` switches branch but does not advance it — staging was 8 commits behind `origin/development` after deploy
- After checkout, now resets to `origin/<ref>` to advance to remote tip
- Falls back to `git reset --hard <ref>` for commit SHA refs (no-op if already there)

## Test plan

- [ ] Trigger deploy workflow with `development` ref, verify staging reflects latest commits
- [ ] Optionally trigger with a commit SHA to confirm fallback path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)