### PR TITLE
Fix: purge contributor pages from Kinsta and Cloudflare cache on post publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Purge contributor pages from Kinsta and Cloudflare cache on post publish (including `?is_full_archive=true` variant)
+
 ## [4.6.0] - 2026-05-06
 
 ### Changed

--- a/lib/functions-hooks.php
+++ b/lib/functions-hooks.php
@@ -119,6 +119,7 @@ function nm_purge_contributor_pages_cloudflare( $urls, $post_id ) {
     $url = get_permalink( $contributor_id );
     if ( $url ) {
       $urls[] = $url;
+      $urls[] = add_query_arg( 'is_full_archive', 'true', $url );
     }
   }
 

--- a/lib/functions-hooks.php
+++ b/lib/functions-hooks.php
@@ -22,6 +22,110 @@ function nm_flush_cache_on_theme_options_save( $object_id, $updated, $cmb, $obje
   }
 }
 add_action( 'cmb2_save_options-page_fields', 'nm_flush_cache_on_theme_options_save', 10, 4 );
+
+/**
+ * Track the post being published so we can purge its contributor pages via the Kinsta cache filter.
+ * Must run at priority 9 — before Kinsta's transition_post_status callback at priority 10.
+ *
+ * @param string  $new_status New post status.
+ * @param string  $old_status Old post status.
+ * @param WP_Post $post       Post object.
+ */
+function nm_track_post_for_contributor_purge( $new_status, $old_status, $post ) {
+  if ( 'publish' !== $new_status ) {
+    return;
+  }
+  if ( wp_is_post_revision( $post->ID ) || wp_is_post_autosave( $post->ID ) ) {
+    return;
+  }
+  nm_contributor_purge_post_id( $post->ID );
+}
+add_action( 'transition_post_status', 'nm_track_post_for_contributor_purge', 9, 3 );
+
+/**
+ * Static store for the post ID currently being cache-purged.
+ *
+ * @param int|null $set Post ID to store, or null to retrieve.
+ * @return int|null
+ */
+function nm_contributor_purge_post_id( $set = null ) {
+  static $post_id = null;
+  if ( null !== $set ) {
+    $post_id = $set;
+  }
+  return $post_id;
+}
+
+/**
+ * Inject contributor page URLs into Kinsta's immediate cache purge list.
+ *
+ * Kinsta only purges the post itself, home, and taxonomy/date archives. It has no
+ * awareness of the _cmb_contributors post meta relation, so contributor pages go stale.
+ * This filter adds each linked contributor's permalink to the immediate purge batch.
+ *
+ * @param array $purge_request Kinsta immediate purge request (keys: 'group|*' / 'single|*', values: protocol-stripped URLs).
+ * @return array
+ */
+function nm_purge_contributor_pages_on_post_publish( $purge_request ) {
+  $post_id = nm_contributor_purge_post_id();
+  if ( ! $post_id ) {
+    return $purge_request;
+  }
+
+  $contributors_meta = get_post_meta( $post_id, '_cmb_contributors', true );
+  if ( empty( $contributors_meta ) ) {
+    return $purge_request;
+  }
+
+  foreach ( explode( ',', $contributors_meta ) as $contributor_id ) {
+    $contributor_id = (int) trim( $contributor_id );
+    if ( ! $contributor_id ) {
+      continue;
+    }
+    $url = get_permalink( $contributor_id );
+    if ( ! $url ) {
+      continue;
+    }
+    // group| purges the contributor URL and all paginated sub-pages (/page/2/ etc).
+    $purge_request[ 'group|contributor_' . $contributor_id ] = str_replace( array( 'http://', 'https://' ), '', $url );
+  }
+
+  return $purge_request;
+}
+add_filter( 'KinstaCache/purgeImmediate', 'nm_purge_contributor_pages_on_post_publish' );
+
+/**
+ * Add contributor page URLs to Cloudflare's per-post cache purge list.
+ *
+ * The Cloudflare plugin purges taxonomies, WP author, and the post itself but has no
+ * awareness of _cmb_contributors. This filter injects the linked contributor permalinks
+ * so Cloudflare serves fresh pages after a post is published or updated.
+ *
+ * @param array $urls   URLs already queued for Cloudflare purge.
+ * @param int   $post_id Post ID triggering the purge.
+ * @return array
+ */
+function nm_purge_contributor_pages_cloudflare( $urls, $post_id ) {
+  $contributors_meta = get_post_meta( $post_id, '_cmb_contributors', true );
+  if ( empty( $contributors_meta ) ) {
+    return $urls;
+  }
+
+  foreach ( explode( ',', $contributors_meta ) as $contributor_id ) {
+    $contributor_id = (int) trim( $contributor_id );
+    if ( ! $contributor_id ) {
+      continue;
+    }
+    $url = get_permalink( $contributor_id );
+    if ( $url ) {
+      $urls[] = $url;
+    }
+  }
+
+  return $urls;
+}
+add_filter( 'cloudflare_purge_by_url', 'nm_purge_contributor_pages_cloudflare', 10, 2 );
+
 /**
  * Hook template_redirect to 301 redirect author pages to the homepage
  * Author pages are those created for WP users and thus do not relate to any real content

--- a/lib/functions-hooks.php
+++ b/lib/functions-hooks.php
@@ -86,7 +86,7 @@ function nm_purge_contributor_pages_on_post_publish( $purge_request ) {
     if ( ! $url ) {
       continue;
     }
-    // group| purges the contributor URL and all paginated sub-pages (/page/2/ etc).
+    // group| purges the contributor URL and all sub-paths beneath it.
     $purge_request[ 'group|contributor_' . $contributor_id ] = str_replace( array( 'http://', 'https://' ), '', $url );
   }
 


### PR DESCRIPTION
## Summary

- Contributor pages were going stale after post publish because both Kinsta and Cloudflare cache layers have no awareness of the `_cmb_contributors` post meta relation
- Hooks into `KinstaCache/purgeImmediate` to inject contributor permalinks into Kinsta's purge batch (using `group|` prefix to also clear paginated sub-pages)
- Hooks into `cloudflare_purge_by_url` to inject the same contributor permalinks into Cloudflare's purge batch
- Uses a static post ID store (set at `transition_post_status` priority 9, before Kinsta's priority 10 callback) to make the Kinsta filter aware of which post triggered the purge

## Test plan

- [ ] Publish a new post with a contributor assigned via the contributors meta field
- [ ] Check the contributor's page — should reflect the new post immediately
- [ ] Update an already-published post, confirm contributor page cache is also cleared
- [ ] Confirm no regressions on normal post publish (home page, category pages still purge correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)