### PR TITLE
Fix: include contributor, event and job CPTs in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include contributor, event, and job post types in site search results
+
 ## [4.6.0] - 2026-05-06
 
 ### Changed

--- a/lib/functions-filters.php
+++ b/lib/functions-filters.php
@@ -1,5 +1,21 @@
 <?php
 /**
+ * Include custom post types in front-end search results.
+ *
+ * WP main query defaults to post_type='post' for search even when CPTs are
+ * registered with exclude_from_search=false. This hook makes the intent explicit.
+ * notice is excluded (registered with exclude_from_search=true; no standalone value).
+ *
+ * @param WP_Query $query The current query.
+ */
+function nm_search_include_cpts( WP_Query $query ) {
+  if ( $query->is_search() && $query->is_main_query() && ! is_admin() ) {
+    $query->set( 'post_type', array( 'post', 'contributor', 'event', 'job' ) );
+  }
+}
+add_action( 'pre_get_posts', 'nm_search_include_cpts' );
+
+/**
  * Add classes to pagination links
  *
  * @param string $attributes Existing link attributes.

--- a/lib/functions-filters.php
+++ b/lib/functions-filters.php
@@ -10,7 +10,10 @@
  */
 function nm_search_include_cpts( WP_Query $query ) {
   if ( $query->is_search() && $query->is_main_query() && ! is_admin() ) {
-    $query->set( 'post_type', array( 'post', 'contributor', 'event', 'job' ) );
+    $existing = $query->get( 'post_type' );
+    if ( empty( $existing ) ) {
+      $query->set( 'post_type', array( 'post', 'contributor', 'event', 'job' ) );
+    }
   }
 }
 add_action( 'pre_get_posts', 'nm_search_include_cpts' );


### PR DESCRIPTION
## Summary

- Adds `pre_get_posts` hook (`nm_search_include_cpts`) to include `contributor`, `event`, and `job` post types in front-end search results
- WP main query defaults to `post_type='post'` for search even when CPTs are registered with `exclude_from_search=false` — this hook makes the intent explicit
- `notice` CPT excluded (registered with `exclude_from_search=true`; no standalone search value)

## Test plan

- [ ] Search for a known contributor name — contributor result appears
- [ ] Search for a known event title — event result appears
- [ ] Search for a known job title — job result appears
- [ ] Admin search unaffected (hook guards `! is_admin()`)
- [ ] Pagination still works on search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)