### PR TITLE
Reliability: null derefs, N+1, is_main_query guards, WP_Error checks

### DIFF
--- a/lib/custom-gallery.php
+++ b/lib/custom-gallery.php
@@ -3,6 +3,10 @@ remove_shortcode( 'gallery', 'gallery_shortcode' );
 function my_gallery_shortcode( $attr ) {
   $post = get_post();
 
+  if ( ! $post ) {
+    return '';
+  }
+
   static $instance = 0;
   ++$instance;
 

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -138,7 +138,7 @@ function nm_serial_podcast_redirect() {
   if ( ! empty( $match ) ) {
     $matched_category = array_values( $match )[0];
     $link = get_term_link( $matched_category );
-    if ( $link && isset( $post->post_name ) ) {
+    if ( ! is_wp_error( $link ) && isset( $post->post_name ) ) {
       wp_safe_redirect( $link . '#' . $post->post_name, 301 );
       exit;
     }
@@ -504,15 +504,15 @@ function nm_is_article( $post_id = null ) {
     return false;
   }
 
+  // Resolve articles term ID once outside the closure to avoid N+1 DB calls per category.
+  $articles_term    = get_term_by( 'slug', 'articles', 'category' );
+  $articles_term_id = $articles_term ? $articles_term->term_id : 0;
+
   // check to see if any of the categories returned match the articles slug or have a parent with the articles id
   $found_in_categories = array_filter(
     $categories,
-    function ( $category ) {
-      if ( $category->slug === 'articles' || $category->parent === get_term_by( 'slug', 'articles', 'category' )->term_id ) {
-        return true;
-      }
-
-      return false;
+    function ( $category ) use ( $articles_term_id ) {
+      return $category->slug === 'articles' || ( $articles_term_id && $category->parent === $articles_term_id );
     }
   ); // check to see if any of the categories returned match the articles slug
 

--- a/lib/functions-filters.php
+++ b/lib/functions-filters.php
@@ -199,7 +199,7 @@ function add_featured_image_to_feed( $content ) {
   global $post;
 
   if ( isset( $post->ID ) && has_post_thumbnail( $post->ID ) ) {
-    return get_the_post_thumbnail( $post->ID, apply_filters( 'rss_featured_image_thumbnail_size', 'large' ), 'data-no-lazysizes' ) . $content;
+    return get_the_post_thumbnail( $post->ID, apply_filters( 'rss_featured_image_thumbnail_size', 'large' ), array( 'data-no-lazysizes' => 'true' ) ) . $content;
   }
   return $content;
 }

--- a/lib/functions-hooks.php
+++ b/lib/functions-hooks.php
@@ -150,7 +150,7 @@ add_action( 'template_redirect', 'nm_disable_author_page' );
  * Changes the main query to display reverse chronological and all posts for serial podcasts
  */
 function podcast_series_pre_get_posts( $query ) {
-  if ( is_admin() ) {
+  if ( is_admin() || ! $query->is_main_query() ) {
     return;
   }
 
@@ -171,7 +171,7 @@ add_action( 'pre_get_posts', 'podcast_series_pre_get_posts' );
  * Hook pre_get_posts to show all posts on Focus archive pages
  */
 function focus_pre_get_posts( $query ) {
-  if ( $query->is_admin() ) {
+  if ( is_admin() || ! $query->is_main_query() ) {
     return;
   }
 

--- a/lib/functions-hooks.php
+++ b/lib/functions-hooks.php
@@ -147,7 +147,7 @@ add_action( 'template_redirect', 'nm_disable_author_page' );
 
 /**
  * Hook pre_get_posts on category archives that match via slug.
- * Changes the main query to display reverse chronological and all posts for serial podcasts
+ * Changes the main query to show all posts in chronological order (oldest first) for serial podcasts.
  */
 function podcast_series_pre_get_posts( $query ) {
   if ( is_admin() || ! $query->is_main_query() ) {

--- a/lib/functions-utility.php
+++ b/lib/functions-utility.php
@@ -48,29 +48,31 @@ function is_single_type( $type, $post ) {
  *
  * @return void
  */
-function pr( $var, $title = null ) {
-  if ( $title ) {
-    echo '<strong>' . $title . '</strong><br>';
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+  function nm_pr( $var, $title = null ) {
+    if ( $title ) {
+      echo '<strong>' . esc_html( $title ) . '</strong><br>';
+    }
+    echo '<pre>';
+    print_r( $var ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
+    echo '</pre>';
   }
-  echo '<pre>';
-  print_r( $var );
-  echo '</pre>';
-}
 
-/** Debug page and template request */
-function debug_page_request() {
-  global $wp, $template;
-  define( 'D4P_EOL', "\r\n" );
-  echo '<!-- Request: ';
-  echo empty( $wp->request ) ? 'None' : esc_html( $wp->request );
-  echo ' -->' . D4P_EOL;
-  echo '<!-- Matched Rewrite Rule: ';
-  echo empty( $wp->matched_rule ) ? 'None' : esc_html( $wp->matched_rule );
-  echo ' -->' . D4P_EOL;
-  echo '<!-- Matched Rewrite Query: ';
-  echo empty( $wp->matched_query ) ? 'None' : esc_html( $wp->matched_query );
-  echo ' -->' . D4P_EOL;
-  echo '<!-- Loaded Template: ';
-  echo basename( $template );
-  echo ' -->' . D4P_EOL;
+  /** Debug page and template request */
+  function debug_page_request() {
+    global $wp, $template;
+    define( 'D4P_EOL', "\r\n" );
+    echo '<!-- Request: ';
+    echo empty( $wp->request ) ? 'None' : esc_html( $wp->request );
+    echo ' -->' . D4P_EOL;
+    echo '<!-- Matched Rewrite Rule: ';
+    echo empty( $wp->matched_rule ) ? 'None' : esc_html( $wp->matched_rule );
+    echo ' -->' . D4P_EOL;
+    echo '<!-- Matched Rewrite Query: ';
+    echo empty( $wp->matched_query ) ? 'None' : esc_html( $wp->matched_query );
+    echo ' -->' . D4P_EOL;
+    echo '<!-- Loaded Template: ';
+    echo basename( $template );
+    echo ' -->' . D4P_EOL;
+  }
 }

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -23,6 +23,10 @@ function get_audio_categories_metabox_array() {
   $return = array();
   $return['none'] = 'None';
 
+  if ( is_wp_error( $terms ) || empty( $terms ) ) {
+    return $return;
+  }
+
   foreach ( $terms as $term ) {
     $return[ $term->slug ] = $term->name; // created slug indexed array of categories names
   }
@@ -42,6 +46,10 @@ function get_all_theme_sections_array() {
 
   $return = array();
   $return['none'] = 'None';
+
+  if ( is_wp_error( $terms ) || empty( $terms ) ) {
+    return $return;
+  }
 
   foreach ( $terms as $term ) {
     $return[ $term->term_id ] = $term->name;

--- a/lib/tinyMCE/extlink-tinymce.js
+++ b/lib/tinyMCE/extlink-tinymce.js
@@ -9,15 +9,9 @@
     jQuery('.mce-i-extlinks').addClass('dashicons-before dashicons-external');
 
     editor.addCommand('extlinks', function () {
-      // Add Command when Button Clicked
-      let text = editor.getContent({
-        format: 'html',
-      }); // Check we have selected some text selected
-
-      text = text.replace(/ href=/g, ' target="_blank" href=');
-      editor.setContent(text);
-
-      return;
+      const html = editor.selection.getContent({ format: 'html' });
+      const updated = html.replace(/ href=/g, ' target="_blank" rel="noopener noreferrer" href=');
+      editor.selection.setContent(updated);
     });
   });
 })();

--- a/lib/tinyMCE/videocaptionshortcode-tinymce.js
+++ b/lib/tinyMCE/videocaptionshortcode-tinymce.js
@@ -11,20 +11,8 @@
     );
 
     editor.addCommand('videocaptionshortcode', function () {
-      let text = editor.getContent({
-        format: 'html',
-      }); // get all the text in editor
-
-      const selectedText = editor.selection.getContent({ format: 'text' }); // get selected text
-
-      text = text.replace(
-        selectedText,
-        `[video-caption]${selectedText}[/video-caption]`
-      ); // replace selected text with shortcode
-
-      editor.setContent(text); // set content with updated text
-
-      return;
+      const selected = editor.selection.getContent({ format: 'html' });
+      editor.selection.setContent(`[video-caption]${selected}[/video-caption]`);
     });
   });
 })();


### PR DESCRIPTION
## Summary

- **N+1 + null deref** (`nm_is_article`): `get_term_by()` was called inside `array_filter` closure — once per category per render. Hoisted outside the closure; added null guard for missing `articles` term.
- **WP_Error unchecked** (`nm_serial_podcast_redirect`): `get_term_link()` return was truthy-checked before string concatenation into `wp_safe_redirect()`. Fixed to `is_wp_error()`.
- **`is_main_query()` missing** (`podcast_series_pre_get_posts`, `focus_pre_get_posts`): both set `posts_per_page = -1` without checking `is_main_query()`, causing the override to leak into sidebar widgets and secondary queries. Fixed. (`order_events_by_meta` in the same file already had the correct guard.)
- **Null deref** (`custom-gallery.php`): `get_post()` can return null outside the loop; added early return.
- **`get_terms()` unchecked** (`get_audio_categories_metabox_array`, `get_all_theme_sections_array`): `get_terms()` returns `WP_Error` when the taxonomy doesn't exist; both functions now guard before iterating.
- **Wrong arg type** (`add_featured_image_to_feed`): `get_the_post_thumbnail()` 3rd arg was a string `'data-no-lazysizes'`; WordPress expects an array of attributes. Fixed to `['data-no-lazysizes' => 'true']`.
- **Unguarded debug helpers** (`functions-utility.php`): `pr()` and `debug_page_request()` were always defined regardless of `WP_DEBUG`. Wrapped in `WP_DEBUG` guard; renamed `pr()` → `nm_pr()` to avoid naming collisions; added `esc_html()` on title output.
- **TinyMCE scope bug** (`extlink-tinymce.js`): command operated on full post content instead of selection — replaced all links in the post. Fixed to `selection.getContent()` / `selection.setContent()`; also adds `rel="noopener noreferrer"`.
- **TinyMCE first-occurrence bug** (`videocaptionshortcode-tinymce.js`): `String.replace` on full content only replaces first match. Fixed to `selection.setContent()` directly.

## Test Plan

- [ ] Category archive for `foreign-agent` or `committed` shows all posts in ASC order; a second widget/query on the page is not affected
- [ ] Focus taxonomy archive loads correctly; secondary queries unaffected
- [ ] Single article renders correctly; no PHP notices in debug log
- [ ] RSS feed includes featured image with correct attributes (no lazysizes breaking feed readers)
- [ ] Job posting redirects work for serial podcast slugs; no PHP warnings on redirect
- [ ] TinyMCE extlinks button affects only selected text, not whole post
- [ ] TinyMCE video-caption button wraps only selected text

🤖 Generated with [Claude Code](https://claude.com/claude-code)