### PR TITLE
Feature: Front page layout editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Front page Layout editor — order banners and product blocks in one sortable admin list (Front Page > Layout); falls back to the historic order until a layout is saved
 - Related Post Gutenberg block — search for posts or events in editor; renders type-specific layout on frontend
 
 ### Changed
@@ -17,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update frontend dependencies: jQuery 3→4, @wordpress/scripts 27→32, Cypress 13→15, cssnano 7→8, postcss-preset-env 10→11, webpack-cli 6→7
 - Share link rendering consolidated into single `render_share_link( $platform, $url, $args )` function; old per-platform functions kept as deprecated wrappers
+
+### Deprecated
+
+- Legacy front-page banner selects — superseded by the Layout editor; retained only to seed the default order. Migration: after deploy, open Front Page > Layout and Save once
 
 ### Fixed
 

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -1,0 +1,52 @@
+# Deprecation Policy
+
+## Rule
+
+**Remove after 4 minor releases, or the next major version, whichever is later.**
+
+| Deprecated in | Earliest removal |
+|---------------|-----------------|
+| 4.3.x | 4.7.0 (4 minors) or 5.0.0 if that comes first |
+| 4.6.x | 4.10.0 or 5.0.0 |
+| 5.0.x | 5.4.0 or 6.0.0 |
+
+The 4-minor / next-major rule provides:
+- Enough deploy cycles for content migrations in the DB to have run
+- At least one planned release after the migration lands before the deprecated code is removed
+- A predictable removal window contributors can rely on
+
+## Annotation format
+
+Every deprecated PHP function or class must have a `@deprecated` docblock tag:
+
+```php
+/**
+ * @deprecated 4.3.0 Use render_share_link() instead.
+ */
+function render_tweet_link( $url, $title = null, $link_text = 'Tweet', $hashtag = null ) {
+  render_share_link( 'twitter', $url, compact( 'title', 'link_text', 'hashtag' ) );
+}
+```
+
+Required elements:
+- `@deprecated X.Y.Z` — version when deprecated (patch = 0 if whole minor)
+- Short replacement note — what to use instead, or `No replacement.` if dead code
+
+No `@deprecated-tier` tag needed — the single rule covers all cases.
+
+## Exceptions
+
+**Remove immediately** (no grace period):
+- Time-gated code whose window has expired (verify with `date`)
+- Code proven unreachable by static analysis (grep confirms zero callers + no dynamic dispatch)
+- Security vulnerability with no safe migration path
+
+**Extend grace period** (document in the deprecation notice):
+- Third-party plugin compatibility that Novara does not control — extend to next major only
+- This should be rare; all theme function callers are internal
+
+## Audit
+
+Run `/deprecation-audit` to produce a triage table: every `@deprecated` symbol, its removal version threshold, caller count, and verdict.
+
+Remove in a dedicated `Refactor:` PR — never bundle with feature work.

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -4,11 +4,11 @@
 
 **Remove after 4 minor releases, or the next major version, whichever is later.**
 
-| Deprecated in | Earliest removal |
+| Deprecated in | Earliest removal (later of 4 minors / next major) |
 |---------------|-----------------|
-| 4.3.x | 4.7.0 (4 minors) or 5.0.0 if that comes first |
-| 4.6.x | 4.10.0 or 5.0.0 |
-| 5.0.x | 5.4.0 or 6.0.0 |
+| 4.3.x | 5.0.0 (later of 4.7.0 and 5.0.0) |
+| 4.6.x | 5.0.0 (later of 4.10.0 and 5.0.0) |
+| 5.0.x | 6.0.0 (later of 5.4.0 and 6.0.0) |
 
 The 4-minor / next-major rule provides:
 - Enough deploy cycles for content migrations in the DB to have run

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -2,18 +2,19 @@
 
 ## Rule
 
-**Remove after 4 minor releases, or the next major version, whichever is later.**
+**Remove after 4 minor releases, or at the next major version if that lands sooner — whichever comes first.**
 
-| Deprecated in | Earliest removal (later of 4 minors / next major) |
+| Deprecated in | Earliest removal |
 |---------------|-----------------|
-| 4.3.x | 5.0.0 (later of 4.7.0 and 5.0.0) |
-| 4.6.x | 5.0.0 (later of 4.10.0 and 5.0.0) |
-| 5.0.x | 6.0.0 (later of 5.4.0 and 6.0.0) |
+| 4.3.x | 4.7.0 (4 minors), or 5.0.0 if it ships first |
+| 4.6.x | 4.10.0 (4 minors), or 5.0.0 if it ships first |
+| 4.7.x | 4.11.0 (4 minors), or 5.0.0 if it ships first |
+| 5.0.x | 5.4.0 (4 minors), or 6.0.0 if it ships first |
 
 The 4-minor / next-major rule provides:
 - Enough deploy cycles for content migrations in the DB to have run
-- At least one planned release after the migration lands before the deprecated code is removed
-- A predictable removal window contributors can rely on
+- At least 4 minor releases of grace after a symbol is deprecated
+- A predictable removal window contributors can rely on, capped at the next major so deprecated code never lingers across a major boundary
 
 ## Annotation format
 

--- a/docs/deprecation.md
+++ b/docs/deprecation.md
@@ -47,6 +47,6 @@ No `@deprecated-tier` tag needed — the single rule covers all cases.
 
 ## Audit
 
-Run `/deprecation-audit` to produce a triage table: every `@deprecated` symbol, its removal version threshold, caller count, and verdict.
+If you use Claude Code, the `deprecation-audit` skill produces a triage table: every `@deprecated` symbol, its removal version threshold, caller count, and verdict. Without it, grep the codebase directly — e.g. `grep -rn "@deprecated" --include="*.php"` — and check each symbol's version against the removal rule above.
 
 Remove in a dedicated `Refactor:` PR — never bundle with feature work.

--- a/docs/plans/front-page-layout-editor.md
+++ b/docs/plans/front-page-layout-editor.md
@@ -1,0 +1,243 @@
+# Front Page Layout Editor Plan
+
+## Goal
+
+Replace the hardcoded order of front-page sections (banners + product show-blocks)
+with a single rearrangeable list in the WP admin. First real step toward a
+WYSIWYG-ish front page editor, built by reusing patterns the theme already has.
+
+Permanent bookends stay hardcoded: **above-the-fold** (top) and **mega-block**
+(bottom). Everything between them becomes editable order.
+
+## Current state (for context)
+
+`front-page.php` renders a fixed sequence between the permanent bookends:
+
+```
+above-the-fold   (permanent, takes args)
+banner 1         (NM_get_option nm_front_page_banner_option_1)
+highlight-block  (optional, own subpage toggle, takes excluded_posts_ids arg)
+novara-live
+banner 2         (…option_2)
+audio
+banner 3         (…option_3)
+downstream
+banner 4         (…option_4)
+acfm             (partials/front-page/show-blocks/audio-acfm.php)
+mega-block       (permanent)
+```
+
+Two relevant existing mechanics we reuse:
+
+1. **Banner slots** — 4 fixed `select` fields, each picks a partial path from one
+   hardcoded `$banner_options` map (`partial path => label`), plus dynamic
+   newsletter-signup options. Rendered by `render_front_page_banner($partial)`,
+   which just includes the partial. (`lib/theme-options/options-front-page.php`)
+2. **Products Bar** (`front_page_links_bar`) — a CMB2 `group` field with
+   `'sortable' => true`, add/remove buttons. Proof that drag-to-reorder
+   repeatable groups already work in this codebase.
+
+Insight that makes this cheap: **banners and product blocks are both just
+partials rendered by path.** They unify into one ordered list of partial picks.
+
+## Design decision (settled)
+
+Two ways to handle blocks that need extra config (e.g. highlight-block needs a
+Section taxonomy term):
+
+- **Option 1 — separate metaboxes (chosen for v1):** layout list stores only the
+  block slug + order. Per-block config lives on its own settings subpage, exactly
+  like today's Highlight Section / Products Bar pages. Config is **per block-type**
+  (one config slot per block), not per-instance.
+- **Option 2 — inline conditional fields (deferred):** per-row conditional fields
+  reveal a block's config inside the sortable row. Gives per-instance config and
+  multiple configured instances of the same block. Cost: CMB2 has **no native
+  per-row conditionals** — needs the third-party `cmb2-conditionals` add-on or
+  custom JS, and repeatable-group + conditional + reorder is the fiddliest corner
+  of CMB2.
+
+**Decision:** ship Option 1. Every product block today is a singleton (one audio,
+one acfm) so per-type config covers every real case. The **block registry**
+(below) is the backbone — moving from Option 1 to Option 2 later sources the
+config field from a different place, not a rewrite. Picking cheap now is not a trap.
+
+### Highlight block: out of scope for v1
+
+It is off by default, has never been used, has no editorial capacity behind it,
+and is the only block with awkward arg-passing (`excluded_posts_ids` dedupe
+against above-the-fold). Leave it hardcoded-and-disabled where it is. Do **not**
+put it in the v1 registry. Fold it in later only if someone actually wants it.
+
+That removes the single hard case from v1: every block in the picker is an
+**arg-less singleton partial**.
+
+## The block registry (backbone)
+
+A single source of truth, PHP array, defined once. The layout editor builds its
+select options from it; rendering loops the saved order and calls each partial.
+
+```php
+/**
+ * @return array<string, array{label:string, partial:string, type:string}>
+ *   Keyed by stable slug. `type` is just for optgroup grouping in the select.
+ */
+function nm_get_front_page_block_registry() {
+  $blocks = array(
+    // Product show-blocks (arg-less singleton partials)
+    'novara-live' => array(
+      'label'   => 'Show block: Novara Live',
+      'partial' => 'partials/front-page/show-blocks/novara-live',
+      'type'    => 'product',
+    ),
+    'audio' => array(
+      'label'   => 'Show block: Audio (Novara FM + ACFM)',
+      'partial' => 'partials/front-page/show-blocks/audio',
+      'type'    => 'product',
+    ),
+    'audio-acfm' => array(
+      'label'   => 'Show block: ACFM',
+      'partial' => 'partials/front-page/show-blocks/audio-acfm',
+      'type'    => 'product',
+    ),
+    'downstream' => array(
+      'label'   => 'Show block: Downstream',
+      'partial' => 'partials/front-page/show-blocks/downstream',
+      'type'    => 'product',
+    ),
+  );
+
+  // Banners: fold the existing $banner_options map in under type 'banner',
+  // keyed by a slug derived from the partial path. Includes the dynamic
+  // newsletter-signup options. (Refactor $banner_options out of
+  // nm_register_front_page_options_metabox into a shared function so both the
+  // registry and any legacy code use one list.)
+  foreach ( nm_get_front_page_banner_options() as $partial => $label ) {
+    if ( ! $partial ) { continue; } // skip the 'None' entry
+    $blocks[ 'banner:' . $partial ] = array(
+      'label'   => $label,
+      'partial' => $partial,
+      'key'     => $partial, // original banner key, passed to render_front_page_banner()
+      'type'    => 'banner',
+    );
+  }
+
+  return $blocks;
+}
+```
+
+Notes:
+- Slugs are **stable identifiers** — saved order references slugs, not labels or
+  array indices, so relabelling or reordering the registry never corrupts saved
+  layouts.
+- Newsletter-signup banners are dynamic (per newsletter ID) — already handled by
+  `get_newsletter_signup_options()`; they flow in automatically.
+
+## Data model
+
+Store the layout as an ordered CMB2 `group` (sortable), one row per section.
+v1 row has a single field: a `select` of registry slugs, grouped by `type` into
+optgroups (Product blocks / Banners).
+
+- Option key: dedicated `nm_front_page_layout_options` subpage ("Layout") — keeps
+  the main Front Page page readable. **(decided)**
+- Field id: `nm_front_page_layout` (group), each row stores `block` => slug.
+- **Disabling a slot = remove the row.** No per-row "None" option. **(decided)**
+- **Capped row count** — soft max of ~12 rows (current between-bookend sections =
+  8 in v1, so 12 gives headroom). **(decided)** Note: CMB2 groups have no native
+  max-rows; enforce by hiding the "Add" button past the cap via a small admin JS,
+  or accept it as a documented soft limit for v1.
+
+Rendering in `front-page.php` (between the permanent bookends):
+
+```php
+$registry = nm_get_front_page_block_registry();
+$layout   = NM_get_option( 'nm_front_page_layout', 'nm_front_page_layout_options', array() );
+
+foreach ( $layout as $row ) {
+  $slug = $row['block'] ?? '';
+  if ( ! isset( $registry[ $slug ] ) ) {
+    continue;
+  }
+  $block = $registry[ $slug ];
+
+  if ( $block['type'] === 'banner' ) {
+    // Banners keep their existing render path — it handles newsletter-signup
+    // partials, retired-option no-ops, and a path-traversal security guard.
+    render_front_page_banner( $block['key'] );
+  } else {
+    get_template_part( $block['partial'] );
+  }
+}
+```
+
+**`render_front_page_banner` stays** (`lib/renderers.php:537`). It is not a dumb
+wrapper — it special-cases `newsletter-signup-{id}` (loads `partials/email-signup`
+with the newsletter ID + mailchimp-key check), no-ops retired option slugs
+(`email-the-cortado`, `email-the-pick`), and enforces a `partials/`-only,
+no-`..` security guard. Banner registry entries therefore store the original
+banner **key** (partial path or `newsletter-signup-{id}`) in a `key` field, and
+the loop passes it straight to `render_front_page_banner`. **(decided)**
+
+## Migration
+
+The current layout must seed the new group so nothing changes visually on launch.
+
+1. **Refactor** `$banner_options` out of `nm_register_front_page_options_metabox`
+   into a shared `nm_get_front_page_banner_options()` (used by both the legacy
+   banner selects and the registry).
+2. **One-shot default seed** for `nm_front_page_layout`: if the layout option is
+   empty, default it to the current hardcoded order, reading the existing
+   `nm_front_page_banner_option_1..4` values for the banner rows:
+
+   ```
+   [highlight-block is excluded — stays hardcoded/disabled]
+   novara-live
+   banner_option_1 value  (if not 'None')
+   audio
+   banner_option_2 value
+   downstream
+   banner_option_3 value
+   audio-acfm
+   banner_option_4 value
+   ```
+
+   Implement as a default-on-read (compute the seed when option is empty) rather
+   than a destructive write, so it is reversible and safe to deploy.
+3. **Keep** the old 4 banner `select` fields for one release as a fallback / until
+   the seed is confirmed working in production, then remove them in a follow-up.
+
+## v1 / v2 split
+
+**v1 (this plan):**
+- Block registry.
+- `nm_get_front_page_banner_options()` refactor.
+- Layout subpage: one sortable group, single select per row.
+- `front-page.php` loops the layout between above-the-fold and mega-block.
+- Default-seed migration preserving current order.
+- highlight-block stays hardcoded + disabled, NOT in the registry.
+
+**v2 (later, only if needed):**
+- Per-instance / conditional config (Option 2) via `cmb2-conditionals` or custom
+  JS — only if a real need for per-instance config or duplicate configured blocks
+  appears.
+- Fold highlight-block into the registry with its Section-taxonomy config (decide:
+  per-type subpage vs inline conditional). Resolve the `excluded_posts_ids` dedupe
+  (e.g. always pass the above-the-fold IDs regardless of the block's position).
+- Possibly split the `audio` block (currently hardcodes Novara FM + ACFM) now that
+  ACFM is its own selectable block.
+
+## Resolved decisions
+
+- **Keep `render_front_page_banner`** and route banner rows through it (carries
+  newsletter handling, retired-option no-ops, security guard).
+- **Dedicated "Layout" subpage** under Front Page options.
+- **Disable a slot by removing its row** — no per-row "None".
+- **Capped at ~12 rows** — soft limit (no native CMB2 max; hide Add button via JS
+  or document as soft cap).
+
+## Risk / cost
+
+- No new dependencies in v1 — pure CMB2 group + existing partial-include render.
+- Reuses two proven in-repo patterns (sortable group, banner partial select).
+- Main risk is the migration seed; mitigated by default-on-read + keeping legacy
+  banner fields one release.

--- a/docs/plans/front-page-layout-editor.md
+++ b/docs/plans/front-page-layout-editor.md
@@ -81,8 +81,11 @@ blocks that don't need it simply ignore it. No per-block special-casing.
 
 ## The block registry (backbone)
 
-A single source of truth, PHP array, defined once. The layout editor builds its
-select options from it; rendering loops the saved order and calls each partial.
+A PHP array source of truth. The admin layout editor builds its select options
+from the full registry (product blocks + banners). At render time only the
+DB-free product half (`nm_get_front_page_product_blocks()`) is consulted, with
+banners routed by slug prefix — so the newsletter query stays off the front end
+(see the render snippet below).
 
 ```php
 /**
@@ -144,8 +147,9 @@ Notes:
 ## Data model
 
 Store the layout as an ordered CMB2 `group` (sortable), one row per section.
-v1 row has a single field: a `select` of registry slugs, grouped by `type` into
-optgroups (Product blocks / Banners).
+v1 row has a single field: a flat `select` of registry slugs (labels prefixed
+"Show block:" / "Banner:" for scannability — CMB2's select has no native
+optgroup support, so a flat list is what shipped).
 
 - Option key: dedicated `nm_front_page_layout_options` subpage ("Layout") — keeps
   the main Front Page page readable. **(decided)**
@@ -159,22 +163,30 @@ optgroups (Product blocks / Banners).
 Rendering in `front-page.php` (between the permanent bookends):
 
 ```php
-$registry = nm_get_front_page_block_registry();
-$layout   = NM_get_option( 'nm_front_page_layout', 'nm_front_page_layout_options', array() );
+// $block_context carries shared args (e.g. excluded_posts_ids) for product blocks.
+foreach ( nm_get_front_page_layout() as $block_slug ) {
+  nm_render_front_page_block( $block_slug, $block_context );
+}
+```
 
-foreach ( $layout as $row ) {
-  $slug = $row['block'] ?? '';
-  if ( ! isset( $registry[ $slug ] ) ) {
-    continue;
+`nm_get_front_page_layout()` returns the saved slug order (or the default seed),
+and `nm_render_front_page_block()` does the routing:
+
+```php
+function nm_render_front_page_block( $slug, $context = array() ) {
+  if ( ! is_string( $slug ) || $slug === '' ) {
+    return;
   }
-  $block = $registry[ $slug ];
-
-  if ( $block['type'] === 'banner' ) {
-    // Banners keep their existing render path — it handles newsletter-signup
-    // partials, retired-option no-ops, and a path-traversal security guard.
-    render_front_page_banner( $block['key'] );
-  } else {
-    get_template_part( $block['partial'] );
+  // Banner slugs route by prefix — no registry lookup, so the newsletter query
+  // never runs on the front end.
+  if ( strpos( $slug, 'banner:' ) === 0 ) {
+    render_front_page_banner( substr( $slug, strlen( 'banner:' ) ) );
+    return;
+  }
+  // Product blocks come from the DB-free product registry; context is forwarded.
+  $products = nm_get_front_page_product_blocks();
+  if ( isset( $products[ $slug ] ) ) {
+    get_template_part( $products[ $slug ]['partial'], null, $context );
   }
 }
 ```
@@ -183,9 +195,8 @@ foreach ( $layout as $row ) {
 wrapper — it special-cases `newsletter-signup-{id}` (loads `partials/email-signup`
 with the newsletter ID + mailchimp-key check), no-ops retired option slugs
 (`email-the-cortado`, `email-the-pick`), and enforces a `partials/`-only,
-no-`..` security guard. Banner registry entries therefore store the original
-banner **key** (partial path or `newsletter-signup-{id}`) in a `key` field, and
-the loop passes it straight to `render_front_page_banner`. **(decided)**
+no-`..` security guard. The banner key (partial path or `newsletter-signup-{id}`)
+is the layout slug minus its `banner:` prefix, passed straight to it. **(decided)**
 
 ## Migration
 

--- a/docs/plans/front-page-layout-editor.md
+++ b/docs/plans/front-page-layout-editor.md
@@ -23,9 +23,12 @@ audio
 banner 3         (…option_3)
 downstream
 banner 4         (…option_4)
-acfm             (partials/front-page/show-blocks/audio-acfm.php)
 mega-block       (permanent)
 ```
+
+(A standalone ACFM show-block is being built in parallel on
+`feature/front-page-acfm-block`; it will be added to the registry when that
+branch is rebuilt on top of this editor. It does not exist on this branch.)
 
 Two relevant existing mechanics we reuse:
 
@@ -56,20 +59,25 @@ Section taxonomy term):
   custom JS, and repeatable-group + conditional + reorder is the fiddliest corner
   of CMB2.
 
-**Decision:** ship Option 1. Every product block today is a singleton (one audio,
-one acfm) so per-type config covers every real case. The **block registry**
-(below) is the backbone — moving from Option 1 to Option 2 later sources the
-config field from a different place, not a rewrite. Picking cheap now is not a trap.
+**Decision:** ship Option 1. Every product block today is a singleton (one audio
+block, one downstream, etc.) so per-type config covers every real case. The
+**block registry** (below) is the backbone — moving from Option 1 to Option 2
+later sources the config field from a different place, not a rewrite. Picking
+cheap now is not a trap.
 
-### Highlight block: out of scope for v1
+### Highlight block: included as a registry block
 
-It is off by default, has never been used, has no editorial capacity behind it,
-and is the only block with awkward arg-passing (`excluded_posts_ids` dedupe
-against above-the-fold). Leave it hardcoded-and-disabled where it is. Do **not**
-put it in the v1 registry. Fold it in later only if someone actually wants it.
+Earlier draft kept highlight-block hardcoded and out of the registry. Reversed
+during review: leaving it pinned outside the list meant enabling it would change
+the historic order relative to the seed. Instead it is a normal registry block
+(Option 1): it appears in the Layout list, its content config stays on its
+existing Highlight Section subpage, and its on/off toggle there still governs
+visibility (disabled → renders nothing).
 
-That removes the single hard case from v1: every block in the picker is an
-**arg-less singleton partial**.
+Its one wrinkle — it needs `excluded_posts_ids` to dedupe against the
+above-the-fold posts — is handled generically: the render loop passes a shared
+`$context` array to every product block via `get_template_part`'s args, and
+blocks that don't need it simply ignore it. No per-block special-casing.
 
 ## The block registry (backbone)
 
@@ -79,11 +87,16 @@ select options from it; rendering loops the saved order and calls each partial.
 ```php
 /**
  * @return array<string, array{label:string, partial:string, type:string}>
- *   Keyed by stable slug. `type` is just for optgroup grouping in the select.
+ *   Keyed by stable slug. `type` routes rendering (product vs banner).
  */
 function nm_get_front_page_block_registry() {
   $blocks = array(
-    // Product show-blocks (arg-less singleton partials)
+    // Product blocks (singleton partials; receive the shared render context)
+    'highlight-block' => array(
+      'label'   => 'Highlight section (configured on its own subpage)',
+      'partial' => 'partials/front-page/highlight-block',
+      'type'    => 'product',
+    ),
     'novara-live' => array(
       'label'   => 'Show block: Novara Live',
       'partial' => 'partials/front-page/show-blocks/novara-live',
@@ -94,16 +107,12 @@ function nm_get_front_page_block_registry() {
       'partial' => 'partials/front-page/show-blocks/audio',
       'type'    => 'product',
     ),
-    'audio-acfm' => array(
-      'label'   => 'Show block: ACFM',
-      'partial' => 'partials/front-page/show-blocks/audio-acfm',
-      'type'    => 'product',
-    ),
     'downstream' => array(
       'label'   => 'Show block: Downstream',
       'partial' => 'partials/front-page/show-blocks/downstream',
       'type'    => 'product',
     ),
+    // 'audio-acfm' added later from feature/front-page-acfm-block.
   );
 
   // Banners: fold the existing $banner_options map in under type 'banner',
@@ -190,14 +199,13 @@ The current layout must seed the new group so nothing changes visually on launch
    `nm_front_page_banner_option_1..4` values for the banner rows:
 
    ```
-   [highlight-block is excluded — stays hardcoded/disabled]
-   novara-live
    banner_option_1 value  (if not 'None')
-   audio
+   highlight-block
+   novara-live
    banner_option_2 value
-   downstream
+   audio
    banner_option_3 value
-   audio-acfm
+   downstream
    banner_option_4 value
    ```
 
@@ -212,19 +220,20 @@ The current layout must seed the new group so nothing changes visually on launch
 - Block registry.
 - `nm_get_front_page_banner_options()` refactor.
 - Layout subpage: one sortable group, single select per row.
-- `front-page.php` loops the layout between above-the-fold and mega-block.
+- `front-page.php` loops the layout between above-the-fold and mega-block,
+  passing a shared `$context` (incl. `excluded_posts_ids`) to product blocks.
 - Default-seed migration preserving current order.
-- highlight-block stays hardcoded + disabled, NOT in the registry.
+- highlight-block included as a registry block; config stays on its subpage,
+  visibility still governed by its existing toggle.
 
 **v2 (later, only if needed):**
 - Per-instance / conditional config (Option 2) via `cmb2-conditionals` or custom
   JS — only if a real need for per-instance config or duplicate configured blocks
   appears.
-- Fold highlight-block into the registry with its Section-taxonomy config (decide:
-  per-type subpage vs inline conditional). Resolve the `excluded_posts_ids` dedupe
-  (e.g. always pass the above-the-fold IDs regardless of the block's position).
+- Add the standalone `audio-acfm` block to the registry once
+  `feature/front-page-acfm-block` is rebuilt on top of this editor.
 - Possibly split the `audio` block (currently hardcodes Novara FM + ACFM) now that
-  ACFM is its own selectable block.
+  ACFM is becoming its own selectable block.
 
 ## Resolved decisions
 
@@ -234,6 +243,8 @@ The current layout must seed the new group so nothing changes visually on launch
 - **Disable a slot by removing its row** — no per-row "None".
 - **Capped at ~12 rows** — soft limit (no native CMB2 max; hide Add button via JS
   or document as soft cap).
+- **highlight-block is a registry block**, not pinned/hardcoded — config on its
+  subpage, `excluded_posts_ids` passed via the shared render context.
 
 ## Risk / cost
 

--- a/front-page.php
+++ b/front-page.php
@@ -21,17 +21,16 @@ get_header();
       'latest_news_posts_ids' => $latest_news_posts_ids,
     ));
 
-    // Highlight block stays pinned directly below the fold. It is excluded from
-    // the Layout editor because it takes args and dedupes against the
-    // above-the-fold posts. Disabled by default via its own settings page.
-    get_template_part('partials/front-page/highlight-block', null, array(
-      'excluded_posts_ids' => array_merge($featured_posts_ids, $latest_news_posts_ids),
-    ));
-
     // Editable layout: banners + product blocks, ordered in Front Page > Layout.
-    // Falls back to the historic order when no layout has been saved.
+    // Falls back to the historic order when no layout has been saved. The shared
+    // context is passed to every product block; only those that need it use it
+    // (e.g. the highlight section dedupes against the above-the-fold posts).
+    $block_context = array(
+      'excluded_posts_ids' => array_merge($featured_posts_ids, $latest_news_posts_ids),
+    );
+
     foreach (nm_get_front_page_layout() as $block_slug) {
-      nm_render_front_page_block($block_slug);
+      nm_render_front_page_block($block_slug, $block_context);
     }
 
     get_template_part('partials/front-page/mega-block');

--- a/front-page.php
+++ b/front-page.php
@@ -1,12 +1,5 @@
 <?php
 get_header();
-
-$banners = array(
-  NM_get_option('nm_front_page_banner_option_1'),
-  NM_get_option('nm_front_page_banner_option_2'),
-  NM_get_option('nm_front_page_banner_option_3'),
-  NM_get_option('nm_front_page_banner_option_4')
-);
 ?>
 
 <!-- main content -->
@@ -28,23 +21,18 @@ $banners = array(
       'latest_news_posts_ids' => $latest_news_posts_ids,
     ));
 
-    render_front_page_banner($banners[0]);
-
+    // Highlight block stays pinned directly below the fold. It is excluded from
+    // the Layout editor because it takes args and dedupes against the
+    // above-the-fold posts. Disabled by default via its own settings page.
     get_template_part('partials/front-page/highlight-block', null, array(
       'excluded_posts_ids' => array_merge($featured_posts_ids, $latest_news_posts_ids),
     ));
 
-    get_template_part('partials/front-page/show-blocks/novara-live');
-
-    render_front_page_banner($banners[1]);
-
-    get_template_part('partials/front-page/show-blocks/audio');
-
-    render_front_page_banner($banners[2]);
-
-    get_template_part('partials/front-page/show-blocks/downstream');
-
-    render_front_page_banner($banners[3]);
+    // Editable layout: banners + product blocks, ordered in Front Page > Layout.
+    // Falls back to the historic order when no layout has been saved.
+    foreach (nm_get_front_page_layout() as $block_slug) {
+      nm_render_front_page_block($block_slug);
+    }
 
     get_template_part('partials/front-page/mega-block');
   ?>

--- a/front-page.php
+++ b/front-page.php
@@ -25,8 +25,13 @@ get_header();
     // Falls back to the historic order when no layout has been saved. The shared
     // context is passed to every product block; only those that need it use it
     // (e.g. the highlight section dedupes against the above-the-fold posts).
+    // Normalise to arrays: get_above_the_fold_featured_post_ids() returns false
+    // when empty (low-content / staging), which would make array_merge throw.
     $block_context = array(
-      'excluded_posts_ids' => array_merge($featured_posts_ids, $latest_news_posts_ids),
+      'excluded_posts_ids' => array_merge(
+        is_array($featured_posts_ids) ? $featured_posts_ids : array(),
+        is_array($latest_news_posts_ids) ? $latest_news_posts_ids : array()
+      ),
     );
 
     foreach (nm_get_front_page_layout() as $block_slug) {

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -154,7 +154,7 @@ function nm_get_front_page_banner_options() {
 function nm_get_front_page_product_blocks() {
   return array(
     'highlight-block' => array(
-      'label'   => 'Highlight section (configured on its own subpage)',
+      'label'   => 'Show block: Highlight section (configured on its own subpage)',
       'partial' => 'partials/front-page/highlight-block',
       'type'    => 'product',
     ),

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -91,11 +91,16 @@ function get_newsletter_signup_options() {
 }
 
 /**
- * Hook in and register a metabox to handle a theme options page and adds a menu item.
+ * Returns the banner options map ( banner key => label ) used by both the
+ * legacy banner selects and the front-page block registry.
+ *
+ * Includes the static banner partials plus the dynamic newsletter-signup
+ * options. The `false => 'None'` entry is only meaningful for the legacy
+ * single-banner selects; the registry skips it.
+ *
+ * @return array
  */
-function nm_register_front_page_options_metabox() {
-  $prefix = 'nm_';
-
+function nm_get_front_page_banner_options() {
   $banner_options = array(
     false                                              => 'None',
     'partials/support-section'                         => 'Support section',
@@ -112,8 +117,167 @@ function nm_register_front_page_options_metabox() {
     'partials/specials/banners/survey-link'            => 'Audience Survey 2026',
   );
 
-  // Merge with newsletter signup options from the newsletter custom post type
-  $banner_options = array_merge( $banner_options, get_newsletter_signup_options() );
+  return array_merge( $banner_options, get_newsletter_signup_options() );
+}
+
+/**
+ * Returns the front-page block registry: every section that can be placed in
+ * the Layout editor, keyed by a stable slug.
+ *
+ * Product blocks are arg-less singleton partials rendered via get_template_part.
+ * Banners reuse the banner options map and carry the original banner `key`,
+ * rendered via render_front_page_banner() (which handles newsletter signups,
+ * retired-option no-ops and a path-traversal guard).
+ *
+ * Slugs are stable identifiers — saved layouts reference slugs, not labels or
+ * indices, so relabelling or reordering the registry never corrupts a layout.
+ *
+ * @return array<string, array{label:string, partial:string, type:string, key?:string}>
+ */
+function nm_get_front_page_block_registry() {
+  $blocks = array(
+    'novara-live' => array(
+      'label'   => 'Show block: Novara Live',
+      'partial' => 'partials/front-page/show-blocks/novara-live',
+      'type'    => 'product',
+    ),
+    'audio'       => array(
+      'label'   => 'Show block: Audio (Novara FM + ACFM)',
+      'partial' => 'partials/front-page/show-blocks/audio',
+      'type'    => 'product',
+    ),
+    'downstream'  => array(
+      'label'   => 'Show block: Downstream',
+      'partial' => 'partials/front-page/show-blocks/downstream',
+      'type'    => 'product',
+    ),
+  );
+
+  foreach ( nm_get_front_page_banner_options() as $key => $label ) {
+    if ( ! $key ) {
+      continue; // skip the 'None' entry
+    }
+    $blocks[ 'banner:' . $key ] = array(
+      'label'   => 'Banner: ' . $label,
+      'partial' => $key,
+      'key'     => $key,
+      'type'    => 'banner',
+    );
+  }
+
+  return $blocks;
+}
+
+/**
+ * Builds the select options ( slug => label ) for a Layout editor row from the
+ * block registry, prefixed with an empty placeholder.
+ *
+ * @return array
+ */
+function nm_get_front_page_layout_select_options() {
+  $options = array( '' => '— Select a section —' );
+
+  foreach ( nm_get_front_page_block_registry() as $slug => $block ) {
+    $options[ $slug ] = $block['label'];
+  }
+
+  return $options;
+}
+
+/**
+ * Returns the ordered front-page layout as an array of registry slugs.
+ *
+ * Falls back to a default seed reproducing the historic hardcoded order when no
+ * layout has been saved. Computed on read (never written), so the migration is
+ * non-destructive and reversible.
+ *
+ * @return string[]
+ */
+function nm_get_front_page_layout() {
+  $saved = NM_get_option( 'nm_front_page_layout', 'nm_front_page_layout_options', array() );
+
+  if ( is_array( $saved ) && ! empty( $saved ) ) {
+    $slugs = array();
+
+    foreach ( $saved as $row ) {
+      if ( ! empty( $row['block'] ) ) {
+        $slugs[] = $row['block'];
+      }
+    }
+
+    if ( ! empty( $slugs ) ) {
+      return $slugs;
+    }
+  }
+
+  return nm_get_front_page_default_layout();
+}
+
+/**
+ * Default layout seed reproducing the historic hardcoded order:
+ * banner 1, Novara Live, banner 2, Audio, banner 3, Downstream, banner 4.
+ *
+ * Reads the legacy banner option values; banner slots set to None are skipped.
+ *
+ * @return string[]
+ */
+function nm_get_front_page_default_layout() {
+  $banner_slug = function ( $option_key ) {
+    $value = NM_get_option( $option_key );
+
+    if ( ! $value || $value === '0' ) {
+      return null;
+    }
+
+    return 'banner:' . $value;
+  };
+
+  $layout = array(
+    $banner_slug( 'nm_front_page_banner_option_1' ),
+    'novara-live',
+    $banner_slug( 'nm_front_page_banner_option_2' ),
+    'audio',
+    $banner_slug( 'nm_front_page_banner_option_3' ),
+    'downstream',
+    $banner_slug( 'nm_front_page_banner_option_4' ),
+  );
+
+  return array_values( array_filter( $layout ) );
+}
+
+/**
+ * Renders a single front-page block by its registry slug.
+ *
+ * Banner blocks route through render_front_page_banner(); product blocks render
+ * their partial directly. Unknown slugs are ignored.
+ *
+ * @param string $slug Registry slug.
+ * @return void
+ */
+function nm_render_front_page_block( $slug ) {
+  $registry = nm_get_front_page_block_registry();
+
+  if ( ! isset( $registry[ $slug ] ) ) {
+    return;
+  }
+
+  $block = $registry[ $slug ];
+
+  if ( $block['type'] === 'banner' ) {
+    render_front_page_banner( $block['key'] );
+    return;
+  }
+
+  get_template_part( $block['partial'] );
+}
+
+/**
+ * Hook in and register a metabox to handle a theme options page and adds a menu item.
+ */
+function nm_register_front_page_options_metabox() {
+  $prefix = 'nm_';
+
+  $banner_options = nm_get_front_page_banner_options();
 
   /**
    * Registers main options page menu item and form.
@@ -663,6 +827,55 @@ function nm_register_front_page_options_metabox() {
             'id'           => 'image',
             'type'         => 'file',
             'preview_size' => 'thumbnail',
+        )
+    );
+
+  /**
+   * Registers the Layout subpage: an ordered, sortable list of the sections
+   * (banners + product blocks) shown between the Above the Fold area and the
+   * Mega Block. Falls back to the historic order when empty (see
+   * nm_get_front_page_layout()).
+   */
+    $layout_options = new_cmb2_box(
+        array(
+            'id'           => 'nm_front_page_layout_options_page',
+            'title'        => 'Layout',
+            'object_types' => array( 'options-page' ),
+            'option_key'   => 'nm_front_page_layout_options',
+            'parent_slug'  => 'nm_front_page_options',
+            'capability'   => 'edit_posts',
+        )
+    );
+
+    $layout_options->add_field(
+        array(
+            'name' => 'Front Page Layout',
+            'desc' => 'Order the sections shown between the Above the Fold area and the Mega Block. Drag to reorder, remove a row to hide that section. Leave empty to use the default order. Keep to a sensible number of sections (~12 max).',
+            'id'   => $prefix . 'front_page_layout_title',
+            'type' => 'title',
+        )
+    );
+
+    $layout_group_field_id = $layout_options->add_field(
+        array(
+            'id'      => $prefix . 'front_page_layout',
+            'type'    => 'group',
+            'options' => array(
+                'group_title'   => __( 'Section {#}', 'nm' ),
+                'add_button'    => __( 'Add Section', 'nm' ),
+                'remove_button' => __( 'Remove Section', 'nm' ),
+                'sortable'      => true,
+            ),
+        )
+    );
+
+    $layout_options->add_group_field(
+        $layout_group_field_id,
+        array(
+            'name'    => 'Section',
+            'id'      => 'block',
+            'type'    => 'select',
+            'options' => nm_get_front_page_layout_select_options(),
         )
     );
 

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -219,6 +219,10 @@ function nm_get_front_page_layout() {
  *
  * Reads the legacy banner option values; banner slots set to None are skipped.
  *
+ * @deprecated 4.7.0 Transitional migration shim. Remove together with the
+ *   legacy banner selects once a layout has been saved in production; after
+ *   that, an empty layout should simply render nothing. Earliest removal
+ *   4.11.0 / 5.0.0 (see docs/deprecation.md).
  * @return string[]
  */
 function nm_get_front_page_default_layout() {
@@ -321,9 +325,19 @@ function nm_register_front_page_options_metabox() {
         )
     );
 
+    /**
+     * Legacy banner slots.
+     *
+     * @deprecated 4.7.0 Superseded by the Front Page > Layout editor. Retained
+     *   only as the source for nm_get_front_page_default_layout()'s seed until a
+     *   layout is saved in production. Earliest removal 4.11.0 / 5.0.0 (see
+     *   docs/deprecation.md). Removal must follow a one-time Save on the Layout
+     *   page in prod, alongside nm_get_front_page_default_layout().
+     */
     $main_options->add_field(
         array(
-            'name' => 'Adverts and banners',
+            'name' => 'Adverts and banners (legacy)',
+            'desc' => 'Deprecated — use the Layout page instead. These selects only seed the default Layout order until a layout is saved.',
             'id'   => $prefix . 'front_page_settings_banners_title',
             'type' => 'title',
         )

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -96,11 +96,14 @@ function get_newsletter_signup_options() {
  *
  * Includes the static banner partials plus the dynamic newsletter-signup
  * options. The `false => 'None'` entry is only meaningful for the legacy
- * single-banner selects; the registry skips it.
+ * single-banner selects; the full registry skips it.
  *
- * Cached per request — get_newsletter_signup_options() runs DB queries and this
- * is called repeatedly during front-page rendering (once per layout row via the
- * registry) and on admin screens.
+ * Called only on admin screens — by the legacy banner selects and by
+ * nm_get_front_page_block_registry() when building the Layout select options.
+ * The front-end render path routes banners by slug prefix and never calls this,
+ * so its get_newsletter_signup_options() DB query stays off front-page requests.
+ * Still cached per request since the admin select and legacy selects both build
+ * the list.
  *
  * @return array
  */
@@ -311,6 +314,10 @@ function nm_get_front_page_default_layout() {
  * @return void
  */
 function nm_render_front_page_block( $slug, $context = array() ) {
+  if ( ! is_string( $slug ) || $slug === '' ) {
+    return; // ignore empty or corrupted layout rows
+  }
+
   $banner_prefix = 'banner:';
 
   if ( strpos( $slug, $banner_prefix ) === 0 ) {

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -244,7 +244,7 @@ function nm_get_front_page_layout() {
     $slugs = array();
 
     foreach ( $saved as $row ) {
-      if ( ! empty( $row['block'] ) ) {
+      if ( is_array( $row ) && ! empty( $row['block'] ) ) {
         $slugs[] = $row['block'];
       }
     }
@@ -266,9 +266,10 @@ function nm_get_front_page_layout() {
  * The highlight section is included in its historic position but stays hidden
  * until enabled on its own settings subpage.
  *
- * @deprecated 4.7.0 Transitional migration shim. Remove together with the
- *   legacy banner selects once a layout has been saved in production; after
- *   that, an empty layout should simply render nothing. Earliest removal
+ * @deprecated 4.7.0 No replacement — superseded by the saved layout
+ *   (nm_get_front_page_layout()). Transitional migration shim: remove together
+ *   with the legacy banner selects once a layout has been saved in production;
+ *   after that, an empty layout should simply render nothing. Earliest removal
  *   4.11.0 (4 minors; see docs/deprecation.md).
  * @return string[]
  */

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -133,35 +133,23 @@ function nm_get_front_page_banner_options() {
 }
 
 /**
- * Returns the front-page block registry: every section that can be placed in
- * the Layout editor, keyed by a stable slug.
+ * Returns the product-block half of the registry, keyed by stable slug.
  *
- * Product blocks are singleton partials rendered via get_template_part. Most are
- * arg-less; the render loop passes a shared context array (see
- * nm_render_front_page_block()) so blocks that need it — e.g. the highlight
- * section, which dedupes against the above-the-fold posts — can read it. Their
- * own content config lives on their existing settings subpages.
+ * Singleton partials rendered via get_template_part. Most are arg-less; the
+ * render loop passes a shared context array (see nm_render_front_page_block())
+ * so blocks that need it — e.g. the highlight section, which dedupes against
+ * the above-the-fold posts — can read it. Their own content config lives on
+ * their existing settings subpages.
  *
- * Banners reuse the banner options map and carry the original banner `key`,
- * rendered via render_front_page_banner() (which handles newsletter signups,
- * retired-option no-ops and a path-traversal guard).
+ * This is intentionally DB-free and is the only registry half consulted on the
+ * front-end render path. Banners are routed by slug prefix at render time (see
+ * nm_render_front_page_block()), so the newsletter-options query never runs on
+ * a front-page request.
  *
- * Slugs are stable identifiers — saved layouts reference slugs, not labels or
- * indices, so relabelling or reordering the registry never corrupts a layout.
- *
- * Cached per request — built once even though nm_render_front_page_block()
- * calls it for every layout row during front-page rendering.
- *
- * @return array<string, array{label:string, partial:string, type:string, key?:string}>
+ * @return array<string, array{label:string, partial:string, type:string}>
  */
-function nm_get_front_page_block_registry() {
-  static $cached = null;
-
-  if ( $cached !== null ) {
-    return $cached;
-  }
-
-  $blocks = array(
+function nm_get_front_page_product_blocks() {
+  return array(
     'highlight-block' => array(
       'label'   => 'Highlight section (configured on its own subpage)',
       'partial' => 'partials/front-page/highlight-block',
@@ -183,6 +171,28 @@ function nm_get_front_page_block_registry() {
       'type'    => 'product',
     ),
   );
+}
+
+/**
+ * Returns the full block registry — product blocks plus every banner — keyed by
+ * stable slug. Used to build the Layout select options in admin.
+ *
+ * Banners reuse the banner options map and carry the original banner `key`,
+ * rendered via render_front_page_banner() (which handles newsletter signups,
+ * retired-option no-ops and a path-traversal guard).
+ *
+ * NOTE: this enumerates banners, which triggers the newsletter-options DB
+ * query. It is only called when building the admin select, never on the
+ * front-end render path. Rendering uses nm_get_front_page_product_blocks()
+ * plus prefix-based banner routing instead.
+ *
+ * Slugs are stable identifiers — saved layouts reference slugs, not labels or
+ * indices, so relabelling or reordering the registry never corrupts a layout.
+ *
+ * @return array<string, array{label:string, partial:string, type:string, key?:string}>
+ */
+function nm_get_front_page_block_registry() {
+  $blocks = nm_get_front_page_product_blocks();
 
   foreach ( nm_get_front_page_banner_options() as $key => $label ) {
     if ( ! $key ) {
@@ -196,14 +206,12 @@ function nm_get_front_page_block_registry() {
     );
   }
 
-  $cached = $blocks;
-
-  return $cached;
+  return $blocks;
 }
 
 /**
  * Builds the select options ( slug => label ) for a Layout editor row from the
- * block registry, prefixed with an empty placeholder.
+ * full block registry, prefixed with an empty placeholder. Admin-only.
  *
  * @return array
  */
@@ -258,7 +266,7 @@ function nm_get_front_page_layout() {
  * @deprecated 4.7.0 Transitional migration shim. Remove together with the
  *   legacy banner selects once a layout has been saved in production; after
  *   that, an empty layout should simply render nothing. Earliest removal
- *   4.11.0 / 5.0.0 (see docs/deprecation.md).
+ *   4.11.0 (4 minors; see docs/deprecation.md).
  * @return string[]
  */
 function nm_get_front_page_default_layout() {
@@ -287,32 +295,34 @@ function nm_get_front_page_default_layout() {
 }
 
 /**
- * Renders a single front-page block by its registry slug.
+ * Renders a single front-page block by its layout slug.
  *
- * Banner blocks route through render_front_page_banner(); product blocks render
- * their partial directly, receiving the shared $context array as template args
- * (blocks that don't need it simply ignore it). Unknown slugs are ignored.
+ * Banner slugs (`banner:<key>`) route through render_front_page_banner() using
+ * the key alone — no registry lookup, so the newsletter-options query is never
+ * triggered on the front end. render_front_page_banner() handles newsletter
+ * signups, retired-option no-ops and a path-traversal guard. Product blocks are
+ * looked up in the DB-free product registry and render their partial, receiving
+ * the shared $context array as template args (blocks that don't need it ignore
+ * it). Unknown slugs are ignored.
  *
- * @param string $slug    Registry slug.
+ * @param string $slug    Layout slug.
  * @param array  $context Shared render context passed to product partials
  *                        (e.g. 'excluded_posts_ids' for the highlight section).
  * @return void
  */
 function nm_render_front_page_block( $slug, $context = array() ) {
-  $registry = nm_get_front_page_block_registry();
+  $banner_prefix = 'banner:';
 
-  if ( ! isset( $registry[ $slug ] ) ) {
+  if ( strpos( $slug, $banner_prefix ) === 0 ) {
+    render_front_page_banner( substr( $slug, strlen( $banner_prefix ) ) );
     return;
   }
 
-  $block = $registry[ $slug ];
+  $products = nm_get_front_page_product_blocks();
 
-  if ( $block['type'] === 'banner' ) {
-    render_front_page_banner( $block['key'] );
-    return;
+  if ( isset( $products[ $slug ] ) ) {
+    get_template_part( $products[ $slug ]['partial'], null, $context );
   }
-
-  get_template_part( $block['partial'], null, $context );
 }
 
 /**
@@ -370,7 +380,7 @@ function nm_register_front_page_options_metabox() {
      *
      * @deprecated 4.7.0 Superseded by the Front Page > Layout editor. Retained
      *   only as the source for nm_get_front_page_default_layout()'s seed until a
-     *   layout is saved in production. Earliest removal 4.11.0 / 5.0.0 (see
+     *   layout is saved in production. Earliest removal 4.11.0 (4 minors; see
      *   docs/deprecation.md). Removal must follow a one-time Save on the Layout
      *   page in prod, alongside nm_get_front_page_default_layout().
      */

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -149,9 +149,18 @@ function nm_get_front_page_banner_options() {
  * Slugs are stable identifiers — saved layouts reference slugs, not labels or
  * indices, so relabelling or reordering the registry never corrupts a layout.
  *
+ * Cached per request — built once even though nm_render_front_page_block()
+ * calls it for every layout row during front-page rendering.
+ *
  * @return array<string, array{label:string, partial:string, type:string, key?:string}>
  */
 function nm_get_front_page_block_registry() {
+  static $cached = null;
+
+  if ( $cached !== null ) {
+    return $cached;
+  }
+
   $blocks = array(
     'highlight-block' => array(
       'label'   => 'Highlight section (configured on its own subpage)',
@@ -187,7 +196,9 @@ function nm_get_front_page_block_registry() {
     );
   }
 
-  return $blocks;
+  $cached = $blocks;
+
+  return $cached;
 }
 
 /**

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -98,9 +98,19 @@ function get_newsletter_signup_options() {
  * options. The `false => 'None'` entry is only meaningful for the legacy
  * single-banner selects; the registry skips it.
  *
+ * Cached per request — get_newsletter_signup_options() runs DB queries and this
+ * is called repeatedly during front-page rendering (once per layout row via the
+ * registry) and on admin screens.
+ *
  * @return array
  */
 function nm_get_front_page_banner_options() {
+  static $options = null;
+
+  if ( $options !== null ) {
+    return $options;
+  }
+
   $banner_options = array(
     false                                              => 'None',
     'partials/support-section'                         => 'Support section',
@@ -117,14 +127,21 @@ function nm_get_front_page_banner_options() {
     'partials/specials/banners/survey-link'            => 'Audience Survey 2026',
   );
 
-  return array_merge( $banner_options, get_newsletter_signup_options() );
+  $options = array_merge( $banner_options, get_newsletter_signup_options() );
+
+  return $options;
 }
 
 /**
  * Returns the front-page block registry: every section that can be placed in
  * the Layout editor, keyed by a stable slug.
  *
- * Product blocks are arg-less singleton partials rendered via get_template_part.
+ * Product blocks are singleton partials rendered via get_template_part. Most are
+ * arg-less; the render loop passes a shared context array (see
+ * nm_render_front_page_block()) so blocks that need it — e.g. the highlight
+ * section, which dedupes against the above-the-fold posts — can read it. Their
+ * own content config lives on their existing settings subpages.
+ *
  * Banners reuse the banner options map and carry the original banner `key`,
  * rendered via render_front_page_banner() (which handles newsletter signups,
  * retired-option no-ops and a path-traversal guard).
@@ -136,17 +153,22 @@ function nm_get_front_page_banner_options() {
  */
 function nm_get_front_page_block_registry() {
   $blocks = array(
-    'novara-live' => array(
+    'highlight-block' => array(
+      'label'   => 'Highlight section (configured on its own subpage)',
+      'partial' => 'partials/front-page/highlight-block',
+      'type'    => 'product',
+    ),
+    'novara-live'     => array(
       'label'   => 'Show block: Novara Live',
       'partial' => 'partials/front-page/show-blocks/novara-live',
       'type'    => 'product',
     ),
-    'audio'       => array(
+    'audio'           => array(
       'label'   => 'Show block: Audio (Novara FM + ACFM)',
       'partial' => 'partials/front-page/show-blocks/audio',
       'type'    => 'product',
     ),
-    'downstream'  => array(
+    'downstream'      => array(
       'label'   => 'Show block: Downstream',
       'partial' => 'partials/front-page/show-blocks/downstream',
       'type'    => 'product',
@@ -215,9 +237,12 @@ function nm_get_front_page_layout() {
 
 /**
  * Default layout seed reproducing the historic hardcoded order:
- * banner 1, Novara Live, banner 2, Audio, banner 3, Downstream, banner 4.
+ * banner 1, highlight section, Novara Live, banner 2, Audio, banner 3,
+ * Downstream, banner 4.
  *
  * Reads the legacy banner option values; banner slots set to None are skipped.
+ * The highlight section is included in its historic position but stays hidden
+ * until enabled on its own settings subpage.
  *
  * @deprecated 4.7.0 Transitional migration shim. Remove together with the
  *   legacy banner selects once a layout has been saved in production; after
@@ -238,6 +263,7 @@ function nm_get_front_page_default_layout() {
 
   $layout = array(
     $banner_slug( 'nm_front_page_banner_option_1' ),
+    'highlight-block',
     'novara-live',
     $banner_slug( 'nm_front_page_banner_option_2' ),
     'audio',
@@ -253,12 +279,15 @@ function nm_get_front_page_default_layout() {
  * Renders a single front-page block by its registry slug.
  *
  * Banner blocks route through render_front_page_banner(); product blocks render
- * their partial directly. Unknown slugs are ignored.
+ * their partial directly, receiving the shared $context array as template args
+ * (blocks that don't need it simply ignore it). Unknown slugs are ignored.
  *
- * @param string $slug Registry slug.
+ * @param string $slug    Registry slug.
+ * @param array  $context Shared render context passed to product partials
+ *                        (e.g. 'excluded_posts_ids' for the highlight section).
  * @return void
  */
-function nm_render_front_page_block( $slug ) {
+function nm_render_front_page_block( $slug, $context = array() ) {
   $registry = nm_get_front_page_block_registry();
 
   if ( ! isset( $registry[ $slug ] ) ) {
@@ -272,7 +301,7 @@ function nm_render_front_page_block( $slug ) {
     return;
   }
 
-  get_template_part( $block['partial'] );
+  get_template_part( $block['partial'], null, $context );
 }
 
 /**
@@ -844,12 +873,12 @@ function nm_register_front_page_options_metabox() {
         )
     );
 
-  /**
-   * Registers the Layout subpage: an ordered, sortable list of the sections
-   * (banners + product blocks) shown between the Above the Fold area and the
-   * Mega Block. Falls back to the historic order when empty (see
-   * nm_get_front_page_layout()).
-   */
+    /**
+     * Registers the Layout subpage: an ordered, sortable list of the sections
+     * (banners + product blocks) shown between the Above the Fold area and the
+     * Mega Block. Falls back to the historic order when empty (see
+     * nm_get_front_page_layout()).
+     */
     $layout_options = new_cmb2_box(
         array(
             'id'           => 'nm_front_page_layout_options_page',


### PR DESCRIPTION
## Summary

Replaces the hardcoded order of front-page sections (banners + product show-blocks) with a single sortable admin list — **Front Page → Layout**. First step toward a WYSIWYG-style front page editor, built by reusing the theme's existing sortable-group and banner-partial patterns.

Plan: `docs/plans/front-page-layout-editor.md`.

## How it works

- **Block registry** — product blocks (highlight section, novara-live, audio, downstream) live in a DB-free `nm_get_front_page_product_blocks()`. The full registry (`nm_get_front_page_block_registry()`) adds all banners for the admin select only.
- **Layout subpage** — sortable CMB2 group, one flat select per row (labels prefixed "Show block:" / "Banner:"). Drag to reorder, remove a row to hide. ~12-row soft cap.
- **Render** — `front-page.php` loops `nm_get_front_page_layout()` between above-the-fold and mega-block. `nm_render_front_page_block()` routes banner slugs by `banner:` prefix straight to `render_front_page_banner()` (newsletter handling + path-traversal guard); product slugs render their partial with a shared `$context`. Banners are not enumerated on the render path, so the newsletter query never runs on a front-page request.
- **Highlight section** is a normal registry block: it sits in the Layout list (and the default seed, in its historic position), its content config stays on its existing Highlight Section subpage, and that page's toggle still governs visibility (disabled → renders nothing). Its `excluded_posts_ids` dedupe is handled via the shared render context.

## Migration (non-destructive)

When no layout is saved, `nm_get_front_page_layout()` falls back to a **seed reproducing the historic order**, read from the legacy banner option values. Computed on read, never written — deploy changes nothing visually.

Legacy banner selects + the seed shim are marked `@deprecated 4.7.0` — earliest removal **4.11.0** (4 minors, or the next major if it ships sooner), per `docs/deprecation.md`.

**Migration step before any future removal:** open Front Page → Layout in prod and **Save once** to persist the seeded order. Documented in CHANGELOG.

## Test plan (local, passed)

1. Front page unchanged on deploy (seed = old order).
2. Front Page → Layout subpage present, empty = default order.
3. Add/reorder/remove rows → front page follows.
4. Banner rows render (incl. newsletter signup).
5. Clear all rows → falls back to default order.

Logic also verified via a stubbed PHP harness: seed order incl. highlight, banner/product routing, shared context delivery, zero newsletter queries on the render path (one when building the admin select), slug-type guard, empty-row drop, unknown-slug ignore.

No asset changes — `dist/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
