### PR TITLE
fix: self-heal staging deploy when theme .git is clobbered

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -78,7 +78,16 @@ jobs:
 
           ssh -i ~/.ssh/kinsta_key -p "$KINSTA_SSH_PORT" \
             "${KINSTA_SSH_USER}@${KINSTA_SSH_HOST}" \
-            "cd public/wp-content/themes/novaramedia-com && \
+            "set -e; \
+             if [ ! -d public/wp-content/themes/novaramedia-com/.git ]; then \
+               echo 'No .git in theme dir — re-cloning (WP Pusher or a manual file copy likely clobbered the repo)'; \
+               cd public/wp-content/themes && \
+               ts=\$(date +%s) && \
+               if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
+               GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/github_deploy_key' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
+               cd ~; \
+             fi; \
+             cd public/wp-content/themes/novaramedia-com && \
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -82,7 +82,7 @@ jobs:
              if [ ! -d public/wp-content/themes/novaramedia-com/.git ]; then \
                echo 'No .git in theme dir — re-cloning (repo appears to have been overwritten by a file copy)'; \
                cd public/wp-content/themes && \
-               ts=\$(date +%s) && \
+               ts=\$(date +%s)-\$RANDOM && \
                if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
                GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/github_deploy_key' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
                cd ~; \

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -80,7 +80,7 @@ jobs:
             "${KINSTA_SSH_USER}@${KINSTA_SSH_HOST}" \
             "set -e; \
              if [ ! -d public/wp-content/themes/novaramedia-com/.git ]; then \
-               echo 'No .git in theme dir — re-cloning (WP Pusher or a manual file copy likely clobbered the repo)'; \
+               echo 'No .git in theme dir — re-cloning (repo appears to have been overwritten by a file copy)'; \
                cd public/wp-content/themes && \
                ts=\$(date +%s) && \
                if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -83,8 +83,8 @@ jobs:
                echo 'No .git in theme dir — re-cloning (repo appears to have been overwritten by a file copy)'; \
                cd public/wp-content/themes && \
                ts=\$(date +%s)-\$RANDOM && \
-               if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
-               GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/github_deploy_key' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
+               if [ -e novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
+               GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
                cd ~; \
              fi; \
              cd public/wp-content/themes/novaramedia-com && \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -58,7 +58,7 @@ jobs:
             "${KINSTA_SSH_USER}@${KINSTA_SSH_HOST}" \
             "set -e; \
              if [ ! -d public/wp-content/themes/novaramedia-com/.git ]; then \
-               echo 'No .git in theme dir — re-cloning (WP Pusher or a manual file copy likely clobbered the repo)'; \
+               echo 'No .git in theme dir — re-cloning (repo appears to have been overwritten by a file copy)'; \
                cd public/wp-content/themes && \
                ts=\$(date +%s) && \
                if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,7 +60,7 @@ jobs:
              if [ ! -d public/wp-content/themes/novaramedia-com/.git ]; then \
                echo 'No .git in theme dir — re-cloning (repo appears to have been overwritten by a file copy)'; \
                cd public/wp-content/themes && \
-               ts=\$(date +%s) && \
+               ts=\$(date +%s)-\$RANDOM && \
                if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
                GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/github_deploy_key' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
                cd ~; \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,7 +56,16 @@ jobs:
 
           ssh -i ~/.ssh/kinsta_key -p "$KINSTA_SSH_PORT" \
             "${KINSTA_SSH_USER}@${KINSTA_SSH_HOST}" \
-            "cd public/wp-content/themes/novaramedia-com && \
+            "set -e; \
+             if [ ! -d public/wp-content/themes/novaramedia-com/.git ]; then \
+               echo 'No .git in theme dir — re-cloning (WP Pusher or a manual file copy likely clobbered the repo)'; \
+               cd public/wp-content/themes && \
+               ts=\$(date +%s) && \
+               if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
+               GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/github_deploy_key' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
+               cd ~; \
+             fi; \
+             cd public/wp-content/themes/novaramedia-com && \
              git fetch origin && \
              git reset --hard HEAD && \
              git clean -fd && \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,8 +61,8 @@ jobs:
                echo 'No .git in theme dir — re-cloning (repo appears to have been overwritten by a file copy)'; \
                cd public/wp-content/themes && \
                ts=\$(date +%s)-\$RANDOM && \
-               if [ -d novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
-               GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new -i ~/.ssh/github_deploy_key' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
+               if [ -e novaramedia-com ]; then mv novaramedia-com ~/novaramedia-com.broken.\$ts; fi && \
+               GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new' git clone git@github.com:novaramedia/novaramedia-com.git novaramedia-com && \
                cd ~; \
              fi; \
              cd public/wp-content/themes/novaramedia-com && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Facebook share URL had malformed query string (`?&u=`); corrected to `?u=`
 - Front-page banner switch used `switch(preg_match())` loose comparison; rewritten as explicit `if/elseif`
 - Fundraising options separator field had duplicate CMB2 id, preventing support-section heading from saving
-- CI deploy self-heals when the staging theme repo's `.git` is missing (e.g. clobbered by a WP Pusher push), re-cloning automatically instead of failing every run
+- CI deploy self-heals when the staging theme repo's `.git` is missing, re-cloning automatically instead of failing every run
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Facebook share URL had malformed query string (`?&u=`); corrected to `?u=`
 - Front-page banner switch used `switch(preg_match())` loose comparison; rewritten as explicit `if/elseif`
 - Fundraising options separator field had duplicate CMB2 id, preventing support-section heading from saving
+- CI deploy self-heals when the staging theme repo's `.git` is missing (e.g. clobbered by a WP Pusher push), re-cloning automatically instead of failing every run
 
 ### Fixed
 

--- a/docs/plans/ci-speedup.md
+++ b/docs/plans/ci-speedup.md
@@ -198,8 +198,10 @@ This should return `403` or `404`. If it returns `200`, contact Kinsta support t
 
 **`fatal: not a git repository`** during CI:
 
-- The theme directory wasn't replaced with a git clone
-- SSH into the server and check: `cd ~/public/wp-content/themes/novaramedia-com && git status`
+- The theme directory's `.git` was clobbered — usually because WP Pusher (or a manual file copy) extracted theme files over the top of the server clone, deleting `.git`.
+- **Self-healing:** the deploy step in both `cypress.yml` and `deploy-staging.yml` now detects a missing `.git` and automatically re-clones `git@github.com:novaramedia/novaramedia-com.git` (using the server's `~/.ssh/github_deploy_key`), moving the clobbered directory to `~/novaramedia-com.broken.<timestamp>` first. No manual intervention needed — the next deploy recovers on its own.
+- If re-clone fails, the deploy key may be missing. SSH in and check: `cd ~/public/wp-content/themes/novaramedia-com && git status`, and re-run Steps 3–6 above.
+- Avoid using WP Pusher to deploy this theme — it bypasses git and breaks the clone. Use the git-based CI deploy instead.
 
 **CI deploy step hangs:**
 

--- a/docs/plans/ci-speedup.md
+++ b/docs/plans/ci-speedup.md
@@ -198,10 +198,10 @@ This should return `403` or `404`. If it returns `200`, contact Kinsta support t
 
 **`fatal: not a git repository`** during CI:
 
-- The theme directory's `.git` was clobbered — usually because WP Pusher (or a manual file copy) extracted theme files over the top of the server clone, deleting `.git`.
-- **Self-healing:** the deploy step in both `cypress.yml` and `deploy-staging.yml` now detects a missing `.git` and automatically re-clones `git@github.com:novaramedia/novaramedia-com.git` (using the server's `~/.ssh/github_deploy_key`), moving the clobbered directory to `~/novaramedia-com.broken.<timestamp>` first. No manual intervention needed — the next deploy recovers on its own.
+- The theme directory's `.git` was clobbered — usually because theme files were copied over the top of the server clone, deleting `.git`.
+- **Self-healing:** the deploy step in both `cypress.yml` and `deploy-staging.yml` now detects a missing `.git` and automatically re-clones the theme repo (using the server's deploy key), moving the clobbered directory to `~/novaramedia-com.broken.<timestamp>` first. No manual intervention needed — the next deploy recovers on its own.
 - If re-clone fails, the deploy key may be missing. SSH in and check: `cd ~/public/wp-content/themes/novaramedia-com && git status`, and re-run Steps 3–6 above.
-- Avoid using WP Pusher to deploy this theme — it bypasses git and breaks the clone. Use the git-based CI deploy instead.
+- Deploy this theme only via the git-based CI deploy — copying files over the top of the server clone bypasses git and breaks the repo.
 
 **CI deploy step hangs:**
 


### PR DESCRIPTION
## Problem

The staging deploy in `cypress.yml` and `deploy-staging.yml` runs git **in the server theme dir** (`git fetch` → `reset` → `checkout`). If theme files get copied over the top of that dir, `.git` is deleted. The next deploy then fails immediately:

```
fatal: not a git repository (or any of the parent directories): .git
```

That kills the deploy step, so theme activation, cache clear, and the **entire Cypress test run** are skipped.

## Fix

Both deploy steps now detect a missing `.git` and self-heal:

- Move the affected directory aside (preserved for inspection, outside the themes dir so WP doesn't list it).
- Re-clone the theme repo using the server's existing deploy key.
- Then run the usual fetch/reset/checkout.

The server's deploy key + ssh config live in `$HOME`, untouched by an in-place file copy, so no key regen is needed. A future clobber recovers automatically.

## Notes

- `DEPLOY_REF` is still validated by the existing regex guard; `COMMIT_SHA` comes from the event. Both passed via `env:`.
- `docs/plans/ci-speedup.md` troubleshooting section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
