### PR TITLE
Fix: close remaining security audit items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Sanitize `$_SERVER['HTTP_REFERER']` and `$_SERVER['HTTP_HOST']` with `wp_unslash()` + `sanitize_text_field()` before use in video autoplay check (`single-post-video.php`)
-- Replace `extract()` with explicit variable assignments in custom gallery shortcode (`custom-gallery.php`)
+- Compare parsed referer host to `$_SERVER['HTTP_HOST']` via `wp_parse_url()` for video autoplay check — prevents spoofing via host name in referer query/path (`partials/singles/single-post-video.php`)
+- Replace `extract()` with explicit variable assignments in custom gallery shortcode (`lib/custom-gallery.php`)
 - Output escaping hardening across article headers, audio post, event archive, quote component, and video title renderer: `esc_html`/`esc_url` for plain-text and URL fields; `esc_html` for standfirst and quote copy (no HTML expected); `wp_kses` without anchors for support box content (prevents nested `<a>`); `rel="nofollow noopener noreferrer"` on podcast subscribe, Google Maps, and Resonance FM external links
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Sanitize `$_SERVER['HTTP_REFERER']` and `$_SERVER['HTTP_HOST']` with `wp_unslash()` + `sanitize_text_field()` before use in video autoplay check (`single-post-video.php`)
+- Replace `extract()` with explicit variable assignments in custom gallery shortcode (`custom-gallery.php`)
 - Output escaping hardening across article headers, audio post, event archive, quote component, and video title renderer: `esc_html`/`esc_url` for plain-text and URL fields; `esc_html` for standfirst and quote copy (no HTML expected); `wp_kses` without anchors for support box content (prevents nested `<a>`); `rel="nofollow noopener noreferrer"` on podcast subscribe, Google Maps, and Resonance FM external links
 
 ### Added

--- a/docs/pr-reviews/pr-422-review-followups.md
+++ b/docs/pr-reviews/pr-422-review-followups.md
@@ -41,7 +41,7 @@ if ( ! $newsletter_id ) {
 
 **File:** `src/blocks/newsletter-signup/edit.js:54`
 
-The block saves the full REST API post object into `attributes.newsletter`, which gets serialised as JSON in `post_content`. Should store only `newsletterId` (integer) and fetch/resolve server-side in `render.php`.
+**Resolved — intentional design.** Block stores `{ id, title }` (not the full post object — that was fixed). The `title` field is used solely for editor UI display (showing the selected newsletter name in the dropdown without an extra API call). `render.php` never reads the stored title — it fetches all data fresh server-side via `get_post_meta()` and `get_the_title()`. No staleness risk on the frontend. See comment in `edit.js`.
 
 ---
 

--- a/lib/custom-gallery.php
+++ b/lib/custom-gallery.php
@@ -35,9 +35,7 @@ function my_gallery_shortcode( $attr ) {
   }
 
   // Setup attributes from options reverting to default
-
-  extract(
-       shortcode_atts(
+  $atts = shortcode_atts(
     array(
       'order'      => 'ASC',
       'orderby'    => 'menu_order ID',
@@ -49,10 +47,20 @@ function my_gallery_shortcode( $attr ) {
       'size'       => 'gallery',
       'include'    => '',
       'exclude'    => '',
-       ),
-       $attr,
-  )
+    ),
+    $attr
   );
+
+  $order      = $atts['order'];
+  $orderby    = $atts['orderby'];
+  $id         = $atts['id'];
+  $itemtag    = $atts['itemtag'];
+  $icontag    = $atts['icontag'];
+  $captiontag = $atts['captiontag'];
+  $columns    = $atts['columns'];
+  $size       = $atts['size'];
+  $include    = $atts['include'];
+  $exclude    = $atts['exclude'];
 
   $id = intval( $id );
 

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -49,9 +49,11 @@
 
         // Soft check: if referer host matches this host, enable autoplay (browser may still block it).
         // parse_url() prevents spoofing via host name in query/path (e.g. evil.com/?next=novaramedia.com).
+        // Host is normalised (port stripped, lowercased) so non-default ports and case differences still match.
         $referer      = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
         $host         = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
-        $referer_host = $referer ? wp_parse_url( $referer, PHP_URL_HOST ) : '';
+        $host         = strtolower( preg_replace( '/:\d+$/', '', $host ) );
+        $referer_host = $referer ? strtolower( (string) wp_parse_url( $referer, PHP_URL_HOST ) ) : '';
         if ( $referer_host && $host && $referer_host === $host ) {
           $autoplay = true;
         }

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -47,8 +47,10 @@
       if (!empty($meta['_cmb_utube'])) {
         $autoplay = false;
 
-        // soft check to see if the link was internal from another part of the website. if so enable autoplay possibility (will depend on browser and config)
-        if (isset($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], $_SERVER['HTTP_HOST'])) {
+        // Soft check: if referer is from this host, enable autoplay (browser may still block it).
+        $referer = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+        $host    = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+        if ( $referer && $host && strpos( $referer, $host ) !== false ) {
           $autoplay = true;
         }
     ?>

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -48,11 +48,11 @@
         $autoplay = false;
 
         // Soft check: if referer host matches this host, enable autoplay (browser may still block it).
-        // parse_url() prevents spoofing via host name in query/path (e.g. evil.com/?next=novaramedia.com).
-        // Host is normalised (port stripped, lowercased) so non-default ports and case differences still match.
+        // wp_parse_url() prevents spoofing via host name in query/path (e.g. evil.com/?next=novaramedia.com).
+        // Both hosts are parsed and lowercased so ports, case differences and IPv6 hosts still match.
         $referer      = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
-        $host         = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
-        $host         = strtolower( preg_replace( '/:\d+$/', '', $host ) );
+        $host_header  = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+        $host         = $host_header ? strtolower( (string) wp_parse_url( 'http://' . $host_header, PHP_URL_HOST ) ) : '';
         $referer_host = $referer ? strtolower( (string) wp_parse_url( $referer, PHP_URL_HOST ) ) : '';
         if ( $referer_host && $host && $referer_host === $host ) {
           $autoplay = true;

--- a/partials/singles/single-post-video.php
+++ b/partials/singles/single-post-video.php
@@ -47,10 +47,12 @@
       if (!empty($meta['_cmb_utube'])) {
         $autoplay = false;
 
-        // Soft check: if referer is from this host, enable autoplay (browser may still block it).
-        $referer = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
-        $host    = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
-        if ( $referer && $host && strpos( $referer, $host ) !== false ) {
+        // Soft check: if referer host matches this host, enable autoplay (browser may still block it).
+        // parse_url() prevents spoofing via host name in query/path (e.g. evil.com/?next=novaramedia.com).
+        $referer      = isset( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+        $host         = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+        $referer_host = $referer ? wp_parse_url( $referer, PHP_URL_HOST ) : '';
+        if ( $referer_host && $host && $referer_host === $host ) {
           $autoplay = true;
         }
     ?>

--- a/src/blocks/newsletter-signup/edit.js
+++ b/src/blocks/newsletter-signup/edit.js
@@ -55,6 +55,8 @@ export default function Edit({ attributes, setAttributes }) {
       setAttributes({ newsletter: null });
       return;
     }
+    // Store id + title for editor UI only. render.php fetches all data fresh
+    // server-side and never reads the stored title — this is intentional.
     setAttributes({ newsletter: { id: post.id, title: post.title.rendered } });
   };
 


### PR DESCRIPTION
## Summary

- **`single-post-video.php`**: sanitize `$_SERVER['HTTP_REFERER']` and `$_SERVER['HTTP_HOST']` with `wp_unslash()` + `sanitize_text_field()` before use in the internal-referer autoplay check; also correct `strpos()` truthy check to explicit `!== false` (truthy check is a latent bug — `strpos` returns `0` for a match at position 0)
- **`lib/custom-gallery.php`**: replace `extract()` with explicit variable assignments — eliminates WPCS flag and variable injection risk; no behaviour change
- **`src/blocks/newsletter-signup/edit.js`**: document that storing `title` in block attributes is intentional editor-only behaviour; `render.php` fetches all data fresh server-side and never reads the stored title
- **`docs/pr-reviews/pr-422-review-followups.md`**: close the newsletter architecture follow-up item with rationale

Closes out the security audit follow-up list from the multi-stage audit (PRs #524–#527).

## Test plan

- [ ] Video single post: autoplay triggers when navigating from another page on the same host; does not trigger from external referrer
- [ ] Gallery shortcode renders correctly on posts with image galleries
- [ ] Newsletter signup block: selecting a newsletter in the editor shows its name; frontend renders correctly with fresh data

🤖 Generated with [Claude Code](https://claude.com/claude-code)