### PR TITLE
Feature: gate in-development front-page blocks to non-production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Front page Layout editor — order banners and product blocks in one sortable admin list (Front Page > Layout); falls back to the historic order until a layout is saved
 - ACFM standalone front-page full-width product block
 - Related Post Gutenberg block — search for posts or events in editor; renders type-specific layout on frontend
-- DYOR front-page section — 50:50 layout with show hero, description, and map CTA left; latest episode embed right; row of 4 recent episodes below
 - Short URL rewrite from `/dyor` to the Do Your Own Research show page
 - Environment gating for in-development front-page blocks via new `nm_is_production()` helper — show on local/development/staging, hide on production
 
 ### Changed
 
-- DYOR front-page blocks (standard + ALT) now hidden on production until ready; remain available on local/development/staging
 - Consolidate rounded-corner CSS helpers: introduce `ui-rounded-box--nested` (4px) for nested inner colour-blocked elements; replace `ui-rounded-image` with `ui-rounded-box` throughout templates
 
 - Update frontend dependencies: jQuery 3→4, @wordpress/scripts 27→32, Cypress 13→15, cssnano 7→8, postcss-preset-env 10→11, webpack-cli 6→7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Related Post Gutenberg block — search for posts or events in editor; renders type-specific layout on frontend
 - DYOR front-page section — 50:50 layout with show hero, description, and map CTA left; latest episode embed right; row of 4 recent episodes below
 - Short URL rewrite from `/dyor` to the Do Your Own Research show page
+- Environment gating for in-development front-page blocks via new `nm_is_production()` helper — show on local/development/staging, hide on production
 
 ### Changed
 
+- DYOR front-page blocks (standard + ALT) now hidden on production until ready; remain available on local/development/staging
 - Consolidate rounded-corner CSS helpers: introduce `ui-rounded-box--nested` (4px) for nested inner colour-blocked elements; replace `ui-rounded-image` with `ui-rounded-box` throughout templates
 
 - Update frontend dependencies: jQuery 3→4, @wordpress/scripts 27→32, Cypress 13→15, cssnano 7→8, postcss-preset-env 10→11, webpack-cli 6→7

--- a/lib/functions-utility.php
+++ b/lib/functions-utility.php
@@ -31,6 +31,20 @@ function url_get_contents( $url ) {
   return $output;
 }
 
+/**
+ * Whether the current site is the production environment.
+ *
+ * Wraps WordPress's native wp_get_environment_type(), which respects the
+ * WP_ENVIRONMENT_TYPE constant (set automatically by Kinsta for production and
+ * staging). Use `! nm_is_production()` to gate not-yet-ready features so they
+ * stay available on local/development/staging but never reach production.
+ *
+ * @return bool True on production, false on local/development/staging.
+ */
+function nm_is_production() {
+  return wp_get_environment_type() === 'production';
+}
+
 /**  A is_single for custom post type */
 function is_single_type( $type, $post ) {
   if ( get_post_type( $post->ID ) === $type ) {

--- a/lib/theme-options/options-front-page.php
+++ b/lib/theme-options/options-front-page.php
@@ -152,7 +152,7 @@ function nm_get_front_page_banner_options() {
  * @return array<string, array{label:string, partial:string, type:string}>
  */
 function nm_get_front_page_product_blocks() {
-  return array(
+  $blocks = array(
     'highlight-block' => array(
       'label'   => 'Show block: Highlight section (configured on its own subpage)',
       'partial' => 'partials/front-page/highlight-block',
@@ -189,6 +189,17 @@ function nm_get_front_page_product_blocks() {
       'type'    => 'product',
     ),
   );
+
+  // Do Your Own Research is still in development. Keep both DYOR blocks
+  // available on local/development/staging but hide them on production — they
+  // disappear from the admin Layout options and, because the front-end render
+  // path looks blocks up in this same registry, never render even if a saved
+  // production layout references them. See nm_render_front_page_block().
+  if ( nm_is_production() ) {
+    unset( $blocks['dyor'], $blocks['dyor-alt'] );
+  }
+
+  return $blocks;
 }
 
 /**
@@ -304,7 +315,6 @@ function nm_get_front_page_default_layout() {
     'highlight-block',
     'novara-live',
     $banner_slug( 'nm_front_page_banner_option_2' ),
-    'dyor',
     'audio',
     $banner_slug( 'nm_front_page_banner_option_3' ),
     'downstream',


### PR DESCRIPTION
## Why

DYOR front-page work isn't ready to ship, but we need to run a release cycle and keep iterating on it in development/staging. Rather than hard-deregistering the blocks, gate them by environment so they stay live everywhere except production.

## What

- **New reusable helper** `nm_is_production()` (`lib/functions-utility.php`) — wraps WordPress's native `wp_get_environment_type()`, which respects Kinsta's auto-set `WP_ENVIRONMENT_TYPE`. Use `! nm_is_production()` to gate any not-yet-ready feature.
- **Gate DYOR blocks** — `nm_get_front_page_product_blocks()` now `unset()`s `dyor` + `dyor-alt` on production. Both the admin Layout options *and* the front-end render path derive from this one registry (`nm_render_front_page_block()` looks blocks up here), so on production the blocks vanish from the admin and never render — even if a saved layout references the slug.
- **Drop `dyor` from the default-layout seed** so production never falls back to rendering it before a layout is saved.

## Behaviour

| Environment | DYOR blocks |
|---|---|
| production | hidden from admin + never render |
| local / development / staging | fully available, unchanged |

## Notes

- PHP-only change — no `dist/` rebuild needed.
- `php -l` clean on both touched PHP files.
- The separate `/dyor` category archive page, metaboxes, and rewrite are untouched — this only affects the front-page product blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)