### PR TITLE
Fix: allow links in about-page names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- About page names render editor-entered links instead of escaping them to literal text
+
 ## [4.7.0] - 2026-06-24
 
 ### Security

--- a/lib/renderers.php
+++ b/lib/renderers.php
@@ -700,7 +700,7 @@ function render_about_group_field( $data ) {
       <?php
       foreach ( $person['name'] as $name ) {
         ?>
-        <div class="about-page__person"><?php echo esc_html( $name ); ?></div>
+        <div class="about-page__person"><?php echo wp_kses_post( $name ); ?></div>
         <?php
       }
       ?>


### PR DESCRIPTION
## Problem
On the [About page](https://novaramedia.com/about/), team/associate names containing `<a>` link markup were rendered as literal escaped text (`&lt;a&gt;...`) instead of clickable links.

## Cause
`render_about_group_field()` in `lib/renderers.php` output names via `esc_html()`, which escapes all HTML.

## Fix
Switched the name output to `wp_kses_post()`, allowing standard post markup (including `<a>`) to render while still stripping scripts/dangerous tags.

Role/title field left on `esc_html()` — names only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)