### PR TITLE
Release: 4.8.1 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.8.1] - 2026-08-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Hotfix release flow: `./scripts/release.sh --hotfix` releases a patch from a `hotfix/*` branch cut from master (documented in `docs/releases.md`)
+
+### Fixed
+
+- Standfirst no longer required on Novara Live posts
+
 ## [4.8.0] - 2026-07-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,5 +22,6 @@ WordPress theme for novaramedia.com. PHP + modular JS (Webpack) + Stylus (nm-sty
 - `docs/specs/` — latest articles news category
 - `docs/testing/` — Cypress testing, workflow notes, testing overview
 - `docs/security.md` — security notes
+- `docs/releases.md` — normal + hotfix release flows (`scripts/release.sh`)
 - `docs/post-deploy-checklist.md` — manual steps after each release (rewrite flushes, one-time admin saves, cache/CDN verification)
 - `docs/extended-changelogs/` — verbose PR changelogs

--- a/docs/post-deploy-checklist.md
+++ b/docs/post-deploy-checklist.md
@@ -16,6 +16,18 @@ for each.
 
 ---
 
+## v4.8.1
+
+### 1. Verify the Novara Live standfirst exemption
+**Edit a Novara Live post in the classic editor → Update with an empty
+Standfirst.** Why: this release exempts posts in the `novara-live` category
+(and its descendants) from the required-standfirst rule. The post should save
+without the validation alert; a post in any other category should still block.
+Tell editorial they no longer need to copy the Short description into the
+Standfirst on Novara Live posts.
+
+---
+
 ## v4.8.0
 
 ### 1. Notify editorial before deploy — old posts may block on Update

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,60 @@
+# Release Flows
+
+Two ways code reaches production. Both end in a PR to `master`; merging that PR
+is the deploy trigger. A human always merges — scripts only create PRs.
+
+Versioning is semver. `scripts/release.sh` wraps `release-it`, which bumps
+`package.json`, converts the `[Unreleased]` section of `CHANGELOG.md` into the
+new version, runs `npm run build`, and stamps `style.css`. The script then
+commits everything as `Build: x.y.z` and pushes.
+
+## Normal release (minor/major)
+
+Ships everything accumulated on `development`.
+
+```
+git checkout development
+./scripts/release.sh [major|minor|patch] [--pr]
+```
+
+- Must run from a clean `development` (no uncommitted or untracked files).
+- Creates PR `development` → `master` titled `Release: x.y.z`.
+- Merge the PR to deploy, then work through `docs/post-deploy-checklist.md`.
+
+## Hotfix release (patch)
+
+For shipping one small fix **without** dragging along whatever is sitting
+unreleased on `development`. Branches from `master` (production state), not
+`development`.
+
+```
+git checkout -b hotfix/<short-name> origin/master
+# make the fix, add a CHANGELOG entry under ## [Unreleased]
+git commit ...
+./scripts/release.sh --hotfix [--pr]
+```
+
+- `--hotfix` requires a `hotfix/*` branch and forces a patch increment.
+- Creates PR `hotfix/<short-name>` → `master` titled `Release: x.y.z (hotfix)`.
+- Merge the PR to deploy, then work through `docs/post-deploy-checklist.md`.
+
+### Back-merge (required, do not skip)
+
+After the hotfix PR merges, `master` holds the fix, the version bump, and the
+changelog entry that `development` lacks. Sync them back so the next normal
+release doesn't collide on version numbers or changelog history:
+
+```
+git fetch origin
+git checkout development && git pull --ff-only origin development
+git merge origin/master && git push origin development
+```
+
+The script prints this reminder at the end of every `--hotfix` run.
+
+### When a hotfix is the wrong tool
+
+If `development` has nothing unreleased (check with
+`git log origin/master..origin/development`), the normal flow ships the same
+code with less ceremony — a hotfix branch buys nothing. Hotfixes exist for when
+`development` is ahead with work you don't want to ship yet.

--- a/lib/meta/cmb2-validation.php
+++ b/lib/meta/cmb2-validation.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: NM Fork: CMB2 js validation for "required" fields
  * Description: Uses js to validate CMB2 fields that have the 'data-validation' attribute set, with rules chosen by data-validation-required / data-validation-word-length
- * Version: 0.4.0
+ * Version: 0.5.0
  *
  * Validates CMB2 meta fields in the editor: hooks the post edit form and our
  * options page forms (Links Bar, Fundraising), and blocks submission with an
@@ -23,6 +23,8 @@
  *   markup-only values (e.g. an empty <p></p> from a wysiwyg) count as empty.
  * - data-validation-required-category="<slug>": required only when the post
  *   is in that category or any of its descendants.
+ * - data-validation-not-required-category="<slug>": suppresses the required
+ *   rules above when the post is in that category or any of its descendants.
  * - data-validation-word-length: value must not exceed this many words.
  *
  * To enable on a CMB2 meta field set the attributes parameters
@@ -96,6 +98,18 @@ function cmb2_after_form_do_js_validation( $post_id, $cmb ) {
     const $htmlbody = $( 'html, body' );
 
     const categoryMap = <?php echo wp_json_encode( $category_map ); ?>;
+
+    // Whether any of the slug's term IDs (itself or a descendant) is ticked.
+    // Match on name+value, not element id: core's Walker_Category_Checklist
+    // suffixes checkbox ids via wp_unique_prefixed_id() (in-category-828-2),
+    // so #in-category-{id} never matches.
+    const has_checked_category = ( slug ) => {
+      const termIds = categoryMap[ slug ] || [];
+
+      return termIds.some( function( id ) {
+        return $( 'input[name="post_category[]"][value="' + id + '"]' ).is( ':checked' );
+      });
+    };
 
     // Non-group wysiwyg fields render via wp_editor() which drops CMB2
     // 'attributes'; they are marked with editor_class instead. Copy the
@@ -234,6 +248,7 @@ function cmb2_after_form_do_js_validation( $post_id, $cmb ) {
         // .attr() not .data(): jQuery data() would coerce numeric-looking
         // slugs (e.g. "2024") to numbers and break the map lookup.
         const requiredCategorySlug = $this.attr( 'data-validation-required-category' );
+        const exemptCategorySlug   = $this.attr( 'data-validation-not-required-category' );
 
         // Globally required, regardless of category.
         let isRequired = $this.data( 'validation-required' ) === true;
@@ -241,14 +256,13 @@ function cmb2_after_form_do_js_validation( $post_id, $cmb ) {
         // Not globally required but has a category rule: required only when
         // one of that category's term IDs (itself or a descendant) is ticked.
         if ( ! isRequired && typeof requiredCategorySlug !== 'undefined' ) {
-          const termIds = categoryMap[ requiredCategorySlug ] || [];
+          isRequired = has_checked_category( requiredCategorySlug );
+        }
 
-          // Match on name+value, not element id: core's Walker_Category_Checklist
-          // suffixes checkbox ids via wp_unique_prefixed_id() (in-category-828-2),
-          // so #in-category-{id} never matches.
-          isRequired = termIds.some( function( id ) {
-            return $( 'input[name="post_category[]"][value="' + id + '"]' ).is( ':checked' );
-          });
+        // An exempt category overrides both rules above: a ticked exempt
+        // category (or descendant) means the field is not required.
+        if ( isRequired && typeof exemptCategorySlug !== 'undefined' && has_checked_category( exemptCategorySlug ) ) {
+          isRequired = false;
         }
 
         // Required (globally or via ticked category): value must be non-empty.
@@ -272,9 +286,10 @@ function cmb2_after_form_do_js_validation( $post_id, $cmb ) {
               remove_failure( $row );
             }
           }
-        } else if ( typeof requiredCategorySlug !== 'undefined' ) {
-          // Conditionally-required field whose category isn't ticked:
-          // clear any stale highlight from a previous failed attempt.
+        } else if ( typeof requiredCategorySlug !== 'undefined' || typeof exemptCategorySlug !== 'undefined' ) {
+          // Conditionally-required field whose category isn't ticked, or a
+          // field exempted by a ticked exempt category: clear any stale
+          // highlight from a previous failed attempt.
           remove_failure( $row );
         }
 

--- a/lib/meta/meta-boxes-post.php
+++ b/lib/meta/meta-boxes-post.php
@@ -23,12 +23,13 @@ function nm_cmb_post_metaboxes() {
   $meta_boxes->add_field(
        array(
     'name'       => __( 'Standfirst', 'cmb' ),
-    'desc'       => __( 'Required!', 'cmb' ),
+    'desc'       => __( 'Required! (not Novara Live)', 'cmb' ),
     'id'         => $prefix . 'standfirst',
     'type'       => 'textarea_small',
     'attributes' => array(
-      'data-validation'          => 'true',
-      'data-validation-required' => 'true',
+      'data-validation'                       => 'true',
+      'data-validation-required'              => 'true',
+      'data-validation-not-required-category' => 'novara-live',
     ),
   )
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "novaramedia-com",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "novaramedia-com",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "ISC",
       "dependencies": {
         "jquery": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "novaramedia-com",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "No Future, Utopia Now",
   "main": "gulpfile.js",
   "scripts": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,25 +8,31 @@
 #   4. Optionally creates PR to master
 #
 # Usage:
-#   ./scripts/release.sh [increment] [--pr]
+#   ./scripts/release.sh [increment] [--pr] [--hotfix]
 #
 #   increment: major | minor | patch (default: minor)
 #   --pr:      create PR to master without prompting
+#   --hotfix:  release from a hotfix/* branch cut from master instead of
+#              development; forces a patch increment. See docs/releases.md
+#              for the full hotfix flow including the back-merge step.
 #
 # Examples:
 #   ./scripts/release.sh                # minor bump, prompt for PR
 #   ./scripts/release.sh patch          # patch bump, prompt for PR
 #   ./scripts/release.sh minor --pr     # minor bump, auto-create PR
 #   ./scripts/release.sh --pr           # minor bump, auto-create PR
+#   ./scripts/release.sh --hotfix --pr  # patch release from hotfix/* branch
 
 set -euo pipefail
 
 INCREMENT="minor"
 AUTO_PR=false
+HOTFIX=false
 
 for arg in "$@"; do
   case "$arg" in
     --pr) AUTO_PR=true ;;
+    --hotfix) HOTFIX=true ;;
     major|minor|patch) INCREMENT="$arg" ;;
     *) echo "Unknown argument: $arg"; exit 1 ;;
   esac
@@ -35,7 +41,17 @@ BRANCH=$(git branch --show-current)
 
 # --- Preflight checks ---
 
-if [ "$BRANCH" != "development" ]; then
+if [ "$HOTFIX" = true ]; then
+  if [[ "$BRANCH" != hotfix/* ]]; then
+    echo "Error: --hotfix must run from a 'hotfix/*' branch cut from master (currently on '$BRANCH')"
+    exit 1
+  fi
+
+  if [ "$INCREMENT" != "patch" ]; then
+    echo "Note: --hotfix forces a patch increment"
+    INCREMENT="patch"
+  fi
+elif [ "$BRANCH" != "development" ]; then
   echo "Error: Must be on 'development' branch (currently on '$BRANCH')"
   exit 1
 fi
@@ -45,8 +61,23 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
-echo "Pulling latest development..."
-git pull --ff-only origin development
+# 'git add -A' below sweeps untracked files into the Build commit, so refuse
+# to run while any exist.
+if git status --porcelain | grep -q '^??'; then
+  echo "Error: Untracked files present. 'git add -A' would commit them. Remove or gitignore them first:"
+  git status --porcelain | grep '^??'
+  exit 1
+fi
+
+if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+  echo "Pulling latest $BRANCH..."
+  git pull --ff-only origin "$BRANCH"
+else
+  # release-it refuses to run without an upstream; fresh hotfix branches
+  # don't have one yet, so push to create it.
+  echo "No upstream set — pushing $BRANCH to origin..."
+  git push -u origin "$BRANCH"
+fi
 
 # --- Run release-it ---
 
@@ -69,8 +100,8 @@ git add -A
 git commit -m "Build: $VERSION"
 
 echo ""
-echo "Pushing development..."
-git push origin development
+echo "Pushing $BRANCH..."
+git push -u origin "$BRANCH"
 
 # --- Create PR ---
 
@@ -86,10 +117,13 @@ fi
 if [ "$CREATE_PR" = true ]; then
   CHANGELOG_ENTRY=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
 
+  TITLE="Release: $VERSION"
+  [ "$HOTFIX" = true ] && TITLE="Release: $VERSION (hotfix)"
+
   gh pr create \
     --base master \
-    --head development \
-    --title "Release: $VERSION" \
+    --head "$BRANCH" \
+    --title "$TITLE" \
     --body "$(cat <<EOF
 ## Release $VERSION
 
@@ -105,7 +139,15 @@ EOF
 else
   echo ""
   echo "Skipped PR creation. To create manually:"
-  echo "  gh pr create --base master --head development --title 'Release $VERSION'"
+  echo "  gh pr create --base master --head $BRANCH --title 'Release: $VERSION'"
+fi
+
+if [ "$HOTFIX" = true ]; then
+  echo ""
+  echo "After the PR is merged and deployed, back-merge into development:"
+  echo "  git fetch origin"
+  echo "  git checkout development && git pull --ff-only origin development"
+  echo "  git merge origin/master && git push origin development"
 fi
 
 echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -114,11 +114,11 @@ elif [ -t 0 ]; then
   [[ "$REPLY" =~ ^[Yy]$ ]] && CREATE_PR=true
 fi
 
+TITLE="Release: $VERSION"
+[ "$HOTFIX" = true ] && TITLE="Release: $VERSION (hotfix)"
+
 if [ "$CREATE_PR" = true ]; then
   CHANGELOG_ENTRY=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
-
-  TITLE="Release: $VERSION"
-  [ "$HOTFIX" = true ] && TITLE="Release: $VERSION (hotfix)"
 
   gh pr create \
     --base master \
@@ -139,7 +139,7 @@ EOF
 else
   echo ""
   echo "Skipped PR creation. To create manually:"
-  echo "  gh pr create --base master --head $BRANCH --title 'Release: $VERSION'"
+  echo "  gh pr create --base master --head $BRANCH --title '$TITLE'"
 fi
 
 if [ "$HOTFIX" = true ]; then

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: Novara Media v4
 Theme URI: novaramedia.com
 Description: No Future, Utopia Now
-Version: 4.8.0
+Version: 4.8.1
 Author: Novara Media
 Author URI: novaramedia.com
 */


### PR DESCRIPTION
## Release 4.8.1

## [4.8.1] - 2026-08-19

### Added

- Hotfix release flow: `./scripts/release.sh --hotfix` releases a patch from a `hotfix/*` branch cut from master (documented in `docs/releases.md`)

### Fixed

- Standfirst no longer required on Novara Live posts

---
Generated by `scripts/release.sh`