### PR TITLE
Fix: skip non-published posts in front page featured zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Slack release notification fires again — workflow now matches the `Release: x.y.z` PR titles created by `scripts/release.sh` (#588)
+- Front page featured zones skip non-published posts, falling back to the latest featured post instead of linking to a dead page (#591)
 
 ### Security
 

--- a/lib/functions-custom.php
+++ b/lib/functions-custom.php
@@ -231,6 +231,12 @@ function get_above_the_fold_featured_post_ids() {
   $latest_featured_posts_ids = array_map( 'intval', $latest_featured_posts_ids );
   $featured_posts_ids = array_map( function( $id ) { return empty( $id ) ? 0 : intval( $id ); }, $featured_posts_ids );
 
+  // A saved id can outlive the published post it pointed at: unpublished, scheduled back
+  // into the future, or trashed after being featured. Treat those slots as unset so the
+  // fallback below fills them, rather than putting non-public content on the front page
+  // behind a dead link.
+  $featured_posts_ids = array_map( function( $id ) { return nm_is_published( $id ) ? $id : 0; }, $featured_posts_ids );
+
   for ( $i = 0; $i < 8; $i++ ) {
 
     if ( empty( $featured_posts_ids[ $i ] ) ) { // if the featured post id is not set in the theme options, use the latest featured post
@@ -504,6 +510,24 @@ function nm_is_article( $post_id = null ) {
   }
 
   return false;
+}
+
+/**
+ * Is the post live and publicly visible?
+ * Guards ID-driven renderers, where a saved post id can outlive the published post it
+ * pointed at — unpublished, scheduled back into the future, or trashed. Returns false
+ * for a missing or deleted post too, since get_post_status() gives false for those.
+ *
+ * @param integer $post_id Post ID.
+ *
+ * @return Boolean
+ */
+function nm_is_published( $post_id ) {
+  if ( empty( $post_id ) ) {
+    return false;
+  }
+
+  return get_post_status( $post_id ) === 'publish';
 }
 
 /**

--- a/partials/front-page/above-the-fold/featured-post-primary.php
+++ b/partials/front-page/above-the-fold/featured-post-primary.php
@@ -1,6 +1,6 @@
 <?php
-if ( ! is_numeric( $args['post_id'] ) ) {
-  return;
+if ( ! is_numeric( $args['post_id'] ) || ! nm_is_published( $args['post_id'] ) ) {
+  return; // never render a featured slot pointing at an unpublished, scheduled or trashed post
 }
 
 if ( ! isset( $args['has_huge_headline'] ) ) {
@@ -34,6 +34,7 @@ if ( $show_related && ! empty( $meta['_cmb_related_posts'] ) ) {
   $related_args = array(
     'posts_per_page' => 1,
     'post__in'       => explode( ', ', $meta['_cmb_related_posts'][0] ),
+    'post_status'    => 'publish', // explicit: a logged-in editor would otherwise pull readable private posts
   );
 
   $related_posts = new WP_Query( $related_args );

--- a/partials/front-page/above-the-fold/featured-post-secondary.php
+++ b/partials/front-page/above-the-fold/featured-post-secondary.php
@@ -1,6 +1,6 @@
 <?php
-if ( ! is_numeric( $args['post_id'] ) ) {
-  return;
+if ( ! is_numeric( $args['post_id'] ) || ! nm_is_published( $args['post_id'] ) ) {
+  return; // never render a featured slot pointing at an unpublished, scheduled or trashed post
 }
 
 $featured_post_id = $args['post_id'];

--- a/partials/front-page/above-the-fold/featured-post-tertiary.php
+++ b/partials/front-page/above-the-fold/featured-post-tertiary.php
@@ -1,6 +1,6 @@
 <?php
-if ( ! is_numeric( $args['post_id'] ) ) {
-  return;
+if ( ! is_numeric( $args['post_id'] ) || ! nm_is_published( $args['post_id'] ) ) {
+  return; // never render a featured slot pointing at an unpublished, scheduled or trashed post
 }
 
 if ( ! isset( $args['show_descriptive_text'] ) ) {

--- a/partials/front-page/above-the-fold/featured-posts-block.php
+++ b/partials/front-page/above-the-fold/featured-posts-block.php
@@ -12,15 +12,18 @@ $to_render = array();
 
 for ($i = 0; $i < 4; $i++) { // depending on which block number, get the featured posts ids to display
   $index = $i + (4 * ($args['block_number'] - 1));
-  if (is_numeric($args['featured_posts_ids'][$index])) {
-    $to_render[] = $args['featured_posts_ids'][$index];
-  }
+  $post_id = isset($args['featured_posts_ids'][$index]) ? $args['featured_posts_ids'][$index] : 0;
+
+  // Keyed by position rather than appended: the per-slot options read below are keyed by slot
+  // number, so an unpublished post has to leave its own slot empty instead of promoting the
+  // next post into it. 0 marks an empty slot and is skipped by every render guard below.
+  $to_render[$i] = nm_is_published($post_id) ? $post_id : 0;
 }
 ?>
 <div class="grid-row grid-row--nested<?php if ($args['block_number'] % 2 === 0) { echo " grid-row--reverse"; } ?>">
   <div class="featured-posts__primary grid-item is-l-24 is-xxl-16 mb-4">
     <?php
-    if (is_numeric($to_render[0])) {
+    if (!empty($to_render[0])) {
       get_template_part('partials/front-page/above-the-fold/featured-post-primary', null, array(
         'post_id' => $to_render[0],
         'show_related' => NM_get_option('nm_above_the_fold_featured_' . (1 + (4 * ($args['block_number'] - 1))) . '_show_related', 'nm_front_page_above_the_fold_featured_options'),
@@ -35,7 +38,7 @@ for ($i = 0; $i < 4; $i++) { // depending on which block number, get the feature
     <div class="grid-row grid-row--nested">
       <div class="grid-item is-l-12 is-xxl-24">
   <?php
-    if (is_numeric($to_render[1])) {
+    if (!empty($to_render[1])) {
       get_template_part('partials/front-page/above-the-fold/featured-post-secondary', null, array(
         'post_id' => $to_render[1],
         'container_classes' => 'mb-4',
@@ -45,14 +48,14 @@ for ($i = 0; $i < 4; $i++) { // depending on which block number, get the feature
       </div>
       <div class="grid-item is-l-12 is-xxl-24">
   <?php
-    if (is_numeric($to_render[2])) {
+    if (!empty($to_render[2])) {
       get_template_part('partials/front-page/above-the-fold/featured-post-tertiary', null, array(
         'post_id' => $to_render[2],
         'container_classes' => 'mb-4',
       ));
     }
 
-    if (is_numeric($to_render[3])) {
+    if (!empty($to_render[3])) {
       get_template_part('partials/front-page/above-the-fold/featured-post-tertiary', null, array(
         'post_id' => $to_render[3],
       ));


### PR DESCRIPTION
## What

Front page above-the-fold featured zones now skip posts that are not `publish`.

- `nm_is_published()` added to `lib/functions-custom.php` — true only for a live post, false for draft, pending, scheduled, private, trashed, and for a missing or deleted id.
- `get_above_the_fold_featured_post_ids()` zeroes any saved option id that fails that check. The slot then goes through the fallback that already existed for unset slots, filling from the newest published `_cmb_featurable` post — so the grid stays full instead of gaining a hole.
- The four featured partials (`featured-post-primary/secondary/tertiary.php`, `featured-posts-block.php`) check status themselves too, so no caller can render a non-public post through them.

## Why

Fixes #591. The zones rendered whatever ids were saved in the Above the Fold: Featured options with no status check, so a post unpublished, scheduled forward, or trashed after being featured stayed on the front page — title and thumbnail public, link pointing at a dead page.

## Two things found on the way

**Empty slots rendered empty cards.** An unfilled slot is the integer `0`, which passed the old `is_numeric()` guard, so a thin featurable pool rendered a card with no title linking to `get_permalink(0)`. The status guard closes that, since `get_post_status(0)` is `false`.

**Slot settings could attach to the wrong post.** `featured-posts-block.php` appended to `$to_render`, but the per-slot options (`show_related`, `more_on_section`, `is_product_linked`) are read by slot number. Skipping a post would have shifted the next one up into another slot's settings. It is now keyed by position, so a skipped post leaves its own slot empty.

Also pins `post_status` on the related-posts `WP_Query` in the primary partial. It relied on WP_Query's front-end default, which lets a logged-in editor pull a readable private post.

## Testing

Local DevKinsta, `php -l` clean on all five PHP files.

| Case | Before | After |
|---|---|---|
| Featured slot 3 set to a draft | Draft title and `?p=51048` link on the front page | Absent; slot filled from fallback |
| `nm_is_published()` for published / draft / missing id / `0` | — | `true` / `false` / `false` / `false` |
| All featured posts published | — | Rendered page byte-identical to `development` (222,821 bytes), featured zone structure unchanged |

No PHP warnings or notices in the rendered output. PHP only, no `dist/` changes, no build required.

## Not in this PR

Editor-side warnings for non-published featured ids — that is the separate Above the Fold options UX work noted on the issue. This is the render-side half.

The highlight block and latest-articles zones were checked per the issue's note: both are query-driven with `post_status => 'publish'`, so they were never exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
